### PR TITLE
[FE] Login Page UI

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-import IconPage from './IconPage';
 import Router from './Router';
 
 function App() {
   return (
     <div>
       <Router />
-      <h1>ISSUE TRACKER</h1>
-      <IconPage />
     </div>
   );
 }

--- a/FE/src/components/Button/index.tsx
+++ b/FE/src/components/Button/index.tsx
@@ -2,37 +2,62 @@ import React from 'react';
 
 import * as S from './style';
 
-export const Button: React.FC<
+import { OverridableProps } from '@utils/types';
+
+type ButtonProps<T extends React.ElementType> = OverridableProps<
+  T,
   {
     children: React.ReactNode;
     outlined?: boolean;
     size?: 'sm' | 'md' | 'lg';
-  } & React.ComponentPropsWithoutRef<'button'>
-> = ({ children, outlined = false, size = 'sm', ...rest }) => (
-  <S.Button type="button" outlined={outlined} size={size} {...rest}>
-    <span>{children}</span>
-  </S.Button>
-);
+  }
+>;
 
-export const TextButton: React.FC<
+type TextButtonProps<T extends React.ElementType> = OverridableProps<
+  T,
   {
     children: React.ReactNode;
     size?: 'sm' | 'md';
-  } & React.ComponentPropsWithoutRef<'button'>
-> = ({ children, size = 'sm', ...rest }) => (
-  <S.TextButton size={size} {...rest}>
-    {children}
-  </S.TextButton>
-);
+  }
+>;
 
-export const LoginButton: React.FC<
+type LoginButtonProps<T extends React.ElementType> = OverridableProps<
+  T,
   {
     children: React.ReactNode;
     textColor?: string;
     bgColor?: string;
-  } & React.ComponentPropsWithoutRef<'button'>
-> = ({ children, textColor = '#fff', bgColor = '#000', ...rest }) => (
-  <S.LoginButton bgColor={bgColor} textColor={textColor} {...rest}>
+  }
+>;
+
+export const Button = <T extends React.ElementType = 'button'>({
+  children,
+  outlined = false,
+  size = 'sm',
+  ...restProps
+}: ButtonProps<T>) => (
+  <S.Button type="button" outlined={outlined} size={size} {...restProps}>
+    <span>{children}</span>
+  </S.Button>
+);
+
+export const TextButton = <T extends React.ElementType = 'button'>({
+  children,
+  size = 'sm',
+  ...restProps
+}: TextButtonProps<T>) => (
+  <S.TextButton size={size} {...restProps}>
+    {children}
+  </S.TextButton>
+);
+
+export const LoginButton = <T extends React.ElementType = 'button'>({
+  children,
+  bgColor = '#000',
+  textColor = '#fff',
+  ...restProps
+}: LoginButtonProps<T>) => (
+  <S.LoginButton bgColor={bgColor} textColor={textColor} {...restProps}>
     {children}
   </S.LoginButton>
 );

--- a/FE/src/components/Header/index.tsx
+++ b/FE/src/components/Header/index.tsx
@@ -16,7 +16,7 @@ export default function Header() {
           <I.Logo.Small />
         </S.Logo>
       </Link>
-      <UserAvatar src={defaultImageUrl} size="sm" />
+      <UserAvatar as="button" src={defaultImageUrl} size="lg" />
     </S.HeaderLayer>
   );
 }

--- a/FE/src/components/Header/index.tsx
+++ b/FE/src/components/Header/index.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import * as S from './style';
 
 import I from '@components/Icons';
+import UserAvatar from '@components/UserAvatar';
 
 const defaultImageUrl =
   'https://www.stignatius.co.uk/wp-content/uploads/2020/10/default-user-icon.jpg';
@@ -15,9 +16,7 @@ export default function Header() {
           <I.Logo.Small />
         </S.Logo>
       </Link>
-      <S.UserAvatar>
-        <S.Image src={defaultImageUrl} />
-      </S.UserAvatar>
+      <UserAvatar src={defaultImageUrl} size="sm" />
     </S.HeaderLayer>
   );
 }

--- a/FE/src/components/Header/style.ts
+++ b/FE/src/components/Header/style.ts
@@ -2,27 +2,8 @@ import styled from '@emotion/styled';
 
 import { flexbox } from '@styles/mixin';
 
-export const Image = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
-
 export const Logo = styled.h1`
   cursor: pointer;
-`;
-
-export const UserAvatar = styled.button`
-  border: 2px solid ${({ theme }) => theme.color.body};
-  border-radius: 50%;
-  overflow: hidden;
-  width: 2.75rem;
-  height: 2.75rem;
-  transition: all 500ms;
-
-  &:hover {
-    border-color: ${({ theme }) => theme.color.blue};
-  }
 `;
 
 export const HeaderLayer = styled.header`

--- a/FE/src/components/UserAvatar/index.tsx
+++ b/FE/src/components/UserAvatar/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import * as S from './style';
+
+import { OverridableProps } from '@utils/types';
+
+interface Props {
+  src: string;
+  size?: 'sm' | 'lg';
+  alt?: string;
+}
+
+// T라는 리액트 엘리먼트의 props와 위에 정의한 Props의 props, as props를 가지는 type
+type UserAvatarProps<T extends React.ElementType> = OverridableProps<T, Props>;
+
+const UserAvatar = <T extends React.ElementType = 'div'>({
+  alt = '',
+  size = 'sm',
+  src,
+  as,
+  ...restProps
+}: UserAvatarProps<T>) => (
+  <S.UserAvatar as={as ?? 'div'} size={size} {...restProps}>
+    <S.Image src={src} alt={alt} />
+  </S.UserAvatar>
+);
+
+export default UserAvatar;

--- a/FE/src/components/UserAvatar/style.ts
+++ b/FE/src/components/UserAvatar/style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const UserAvatar = styled.button<{ size: 'sm' | 'lg' }>`
+  border-style: solid;
+  border-color: ${({ theme }) => theme.color.body};
+  border-width: ${({ size }) => (size === 'sm' ? 1 : 2)}px;
+  border-radius: 50%;
+  overflow: hidden;
+  width: ${({ size }) => (size === 'lg' ? 2.75 : 1.25)}rem;
+  height: ${({ size }) => (size === 'lg' ? 2.75 : 1.25)}rem;
+  transition: all 500ms;
+
+  ${({ size, theme }) =>
+    size === 'lg' &&
+    `
+      &:hover {
+        border-color: ${theme.color.blue};
+      }
+    `}
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/FE/src/pages/ButtonPage/index.tsx
+++ b/FE/src/pages/ButtonPage/index.tsx
@@ -16,6 +16,7 @@ export default function ButtonPage() {
           <br />
           <Button outlined>Outlined Small Button</Button>
           <br />
+          <br />
         </div>
         <div>
           <Button size="md">Medium Button</Button>
@@ -24,6 +25,7 @@ export default function ButtonPage() {
             Outlined Medium Button
           </Button>
           <br />
+          <br />
         </div>
         <div>
           <Button size="lg">Large Button</Button>
@@ -31,6 +33,7 @@ export default function ButtonPage() {
           <Button outlined size="lg">
             Outlined Large Button
           </Button>
+          <br />
           <br />
         </div>
         <div>

--- a/FE/src/pages/Login/index.tsx
+++ b/FE/src/pages/Login/index.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import * as S from './style';
 
 import { LoginButton, TextButton } from '@components/Button';
@@ -5,6 +7,8 @@ import I from '@components/Icons';
 import theme from '@styles/theme';
 
 export default function Login() {
+  const navigate = useNavigate();
+
   return (
     <S.LoginPageLayer>
       <S.LogoLayer>
@@ -15,10 +19,19 @@ export default function Login() {
         <LoginButton
           bgColor={theme.color.titleActive}
           textColor={theme.color.offWhite}
+          onClick={() => {
+            navigate('/issue');
+          }}
         >
           GitHub 계정으로 로그인
         </LoginButton>
-        <LoginButton bgColor="#f9e000" textColor="#181600">
+        <LoginButton
+          bgColor="#f9e000"
+          textColor="#181600"
+          onClick={() => {
+            navigate('/issue');
+          }}
+        >
           Kakao 계정으로 로그인
         </LoginButton>
       </S.OAuthLayer>

--- a/FE/src/pages/Login/index.tsx
+++ b/FE/src/pages/Login/index.tsx
@@ -1,3 +1,45 @@
+import * as S from './style';
+
+import { LoginButton, TextButton } from '@components/Button';
+import I from '@components/Icons';
+import theme from '@styles/theme';
+
 export default function Login() {
-  return <div>Login</div>;
+  return (
+    <S.LoginPageLayer>
+      <S.LogoLayer>
+        <I.Logo.Big />
+      </S.LogoLayer>
+
+      <S.OAuthLayer>
+        <LoginButton
+          bgColor={theme.color.titleActive}
+          textColor={theme.color.offWhite}
+        >
+          GitHub 계정으로 로그인
+        </LoginButton>
+        <LoginButton bgColor="#f9e000" textColor="#181600">
+          Kakao 계정으로 로그인
+        </LoginButton>
+      </S.OAuthLayer>
+
+      <TextButton size="sm" disabled css={S.CSSTextButtonMargin}>
+        or
+      </TextButton>
+
+      <S.NormalLoginLayer>
+        <LoginButton
+          bgColor={theme.color.blue}
+          textColor={theme.color.offWhite}
+          disabled
+        >
+          아이디로 로그인
+        </LoginButton>
+      </S.NormalLoginLayer>
+
+      <TextButton size="sm" css={S.CSSTextButtonMargin}>
+        회원가입
+      </TextButton>
+    </S.LoginPageLayer>
+  );
 }

--- a/FE/src/pages/Login/style.ts
+++ b/FE/src/pages/Login/style.ts
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { alignPosXY } from '@styles/mixin';
+
+export const CSSTextButtonMargin = css`
+  margin: 1.5rem 0;
+`;
+
+export const OAuthLayer = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  width: min-content;
+
+  button + button {
+    margin-top: 1rem;
+  }
+`;
+
+export const NormalLoginLayer = styled.form``;
+
+export const LogoLayer = styled.h1`
+  margin-bottom: 3.75rem;
+`;
+
+export const LoginPageLayer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  ${alignPosXY()}
+`;

--- a/FE/src/utils/types.ts
+++ b/FE/src/utils/types.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+// T는 인터페이스
+// T에 선언된 타입을 K에 오버라이드 (&연산자라 제거하는 과정이 필요)
+
+export type Combine<T, K> = T & Omit<K, keyof T>;
+
+// K는 인터페이스, 필수로 들어가야하기 때문에 unknown
+// T 엘리먼트 Props중에 K에 선언된 Props를 오버라이딩
+export type CombineElementProps<
+  T extends React.ElementType,
+  K = unknown,
+> = Combine<K, React.ComponentPropsWithoutRef<T>>;
+
+// T 엘리먼트 Props중에 K에 선언된 Props를 오버라이딩 한 후, as Props를 추가함.
+export type OverridableProps<T extends React.ElementType, K = unknown> = {
+  as?: T;
+} & CombineElementProps<T, K>;


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->
- #6
- 로그인 페이지 UI

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 로그인 페이지 UI
- [x] 유틸리티 type 추가
- [x] 재사용 가능한 컴포넌트 분리

- 현재 로그인 버튼 클릭시 `/issue`로 이동. (임시)
- 유저 전역 상태 정의는 다른 브랜치에서 진행

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
![123](https://user-images.githubusercontent.com/79135734/174067204-e795eb8d-bfb9-4c26-8282-834c91c0e394.PNG)



<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
