### PR TITLE
[Muffin] 타입스크립트에서 any로 타입지정한 부분들 수정, 팝업 로직 분리

### DIFF
--- a/FE/src/components/FilterBar/index.tsx
+++ b/FE/src/components/FilterBar/index.tsx
@@ -1,25 +1,24 @@
 import * as S from './style';
 
 import I from '@components/Icons';
-import { getModalItem } from '@components/Popup/Content';
+import Contents from '@components/Popup/Contents';
 import Popup from '@components/Popup/Popup';
+import { IPopupData } from '@components/Popup/type';
 import useComponentVisible from '@hooks/useComponentVisible.jsx';
 
 export default function FilterBar() {
   const issueFilterData = {
     info: [
-      { status: 'open', name: '열린 이슈' },
-      { status: 'mine', name: '내가 작성한 이슈' },
-      { status: 'assignedToMe', name: '나에게 할당된 이슈' },
-      { status: 'comment', name: '내가 댓글을 남긴 이슈' },
-      { status: 'close', name: '닫힌 이슈' },
+      { id: 1, status: 'open', name: '열린 이슈' },
+      { id: 2, status: 'mine', name: '내가 작성한 이슈' },
+      { id: 3, status: 'assignedToMe', name: '나에게 할당된 이슈' },
+      { id: 4, status: 'comment', name: '내가 댓글을 남긴 이슈' },
+      { id: 5, status: 'close', name: '닫힌 이슈' },
     ],
   };
-  const callback = () => {
-    console.log('데이터 필터되는 콜백함수');
-  };
+
   const { ref, isComponentVisible, setIsComponentVisible } =
-    useComponentVisible(false, callback);
+    useComponentVisible(false);
 
   const handleOnFilterPopup = () => {
     setIsComponentVisible(true);
@@ -33,18 +32,12 @@ export default function FilterBar() {
           {isComponentVisible && (
             <Popup>
               <header>이슈 필터</header>
-              {issueFilterData.info.map((popupData: any) => (
-                <div
-                  className="filter__item-wrapper"
-                  key={`${popupData.status}`}
-                >
-                  <div className="filter__item">
-                    {getModalItem('이슈', popupData)}
-                  </div>
-                  <div className="filter__check">
-                    <I.Circle.Check />
-                  </div>
-                </div>
+              {issueFilterData.info.map((popupData: IPopupData) => (
+                <Contents
+                  key={`popup-${popupData.id}`}
+                  label="이슈"
+                  popupData={popupData}
+                />
               ))}
             </Popup>
           )}

--- a/FE/src/components/FilterBar/style.ts
+++ b/FE/src/components/FilterBar/style.ts
@@ -30,14 +30,20 @@ export const SearchBar = styled.div`
   position: relative;
   border-left: 1px solid ${({ theme }) => theme.color.line};
   ${flexbox({ jc: 'center', ai: 'center' })};
+
+  input {
+    border-radius: 0 0.75rem 0.75rem 0;
+  }
 `;
 
 export const FilterButton = styled.div`
+  position: relative;
   cursor: pointer;
   width: 8rem;
   padding: 0.375rem 1.5rem;
   color: ${({ theme }) => theme.color.label};
   background-color: ${({ theme }) => theme.color.background};
+  border-radius: 0.75rem 0 0 0.75rem;
   ${flexbox({ jc: 'space-between', ai: 'center' })};
   ${typoSmall(700)}
 
@@ -55,8 +61,7 @@ export const FilterBarLayer = styled.form`
   display: inline-flex;
   height: 2.5rem;
   border: 1px solid ${({ theme }) => theme.color.line};
-  border-radius: 11px;
-  overflow: hidden;
+  border-radius: 0.75rem;
 
   &:focus-within {
     border-color: black;

--- a/FE/src/components/Issue/Filter/index.tsx
+++ b/FE/src/components/Issue/Filter/index.tsx
@@ -1,16 +1,16 @@
 import * as S from './style';
 
-import I from '@components/Icons';
 import { FilterLabelTypes } from '@components/Issue/Navigation';
-import { getModalItem } from '@components/Popup/Content';
+import Contents from '@components/Popup/Contents';
 import Popup from '@components/Popup/Popup';
+import { IPopupData } from '@components/Popup/type';
 import useComponentVisible from '@hooks/useComponentVisible.jsx';
 
 interface IFilterProps {
   onPopup: boolean;
   label: FilterLabelTypes;
-  filterPopupData: any;
-  handleFilterClick: (label: string, status: boolean) => void;
+  filterPopupData: IPopupData[];
+  handleFilterClick: (label: FilterLabelTypes, status: boolean) => void;
 }
 
 export default function Filter({
@@ -19,11 +19,8 @@ export default function Filter({
   filterPopupData,
   handleFilterClick,
 }: IFilterProps) {
-  const callback = () => {
-    console.log('데이터 필터되는 콜백함수');
-  };
   const { ref, isComponentVisible, setIsComponentVisible } =
-    useComponentVisible(false, callback);
+    useComponentVisible(false);
   const handleOnFilterPopup = () => {
     handleFilterClick(label, true);
     setIsComponentVisible(true);
@@ -50,18 +47,12 @@ export default function Filter({
           {isComponentVisible && (
             <Popup>
               <header>{label} 필터</header>
-              {filterPopupData.info.map((popupData: any) => (
-                <div
-                  className="filter__item-wrapper"
+              {filterPopupData.map((popupData: IPopupData) => (
+                <Contents
                   key={`popup-${popupData.id}`}
-                >
-                  <div className="filter__item">
-                    {getModalItem(label, popupData)}
-                  </div>
-                  <div className="filter__check">
-                    <I.Circle.Check />
-                  </div>
-                </div>
+                  label={label}
+                  popupData={popupData}
+                />
               ))}
             </Popup>
           )}

--- a/FE/src/components/Issue/Item/index.tsx
+++ b/FE/src/components/Issue/Item/index.tsx
@@ -4,7 +4,19 @@ import { ItemLayer, ContentLayer, Title, Description } from './style';
 
 import I from '@components/Icons';
 
-export default function Item({ issue }: any) {
+interface IIssueItem {
+  id: number;
+  author: { name: string; imageUrl: string }[];
+  date: string;
+  labels: string[];
+  manager: string[];
+  milestone: string;
+  number: number;
+  status: string;
+  title: string;
+}
+
+export default function Item({ issue }: { issue: IIssueItem }) {
   return (
     <ItemLayer>
       <I.CheckBox.Initial color="#D9DBE9" />

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -11,15 +11,15 @@ import { issueState } from '@recoil/atoms/issue';
 import { labelState } from '@recoil/atoms/label';
 import { mileStoneState } from '@recoil/atoms/milestone';
 
-export type FilterLabelTypes =
-  | '이슈'
-  | '담당자'
-  | '레이블'
-  | '마일스톤'
-  | '작성자';
+export type FilterLabelTypes = '담당자' | '레이블' | '마일스톤' | '작성자';
 
 export default function Navigation() {
-  const filterLabels = ['담당자', '레이블', '마일스톤', '작성자'];
+  const filterLabels: FilterLabelTypes[] = [
+    '담당자',
+    '레이블',
+    '마일스톤',
+    '작성자',
+  ];
 
   const assigneeData = useRecoilValue(assigneeState);
   const labelData = useRecoilValue(labelState);
@@ -66,8 +66,8 @@ export default function Navigation() {
     }
   };
 
-  const handleFilterClick = (label: string, status: boolean) => {
-    setPopupState(popupState => ({ ...popupState, [label]: status }));
+  const handleFilterClick = (label: FilterLabelTypes, status: boolean) => {
+    setPopupState(prevPopupState => ({ ...prevPopupState, [label]: status }));
   };
 
   const onPopup = (label: FilterLabelTypes) => !!popupState[label];
@@ -93,12 +93,12 @@ export default function Navigation() {
         </IssueLabel>
       </LeftLayer>
       <RightLayer>
-        {filterLabels.map((label: any) => (
+        {filterLabels.map((label: FilterLabelTypes) => (
           <Filter
             key={label}
             onPopup={onPopup(label)}
             label={label}
-            filterPopupData={filterPopupData[label]}
+            filterPopupData={filterPopupData[label].info}
             handleFilterClick={handleFilterClick}
           />
         ))}

--- a/FE/src/components/Popup/Contents.tsx
+++ b/FE/src/components/Popup/Contents.tsx
@@ -1,0 +1,19 @@
+import I from '@components/Icons';
+import { getModalItem } from '@components/Popup/Item';
+import { IPopupData } from '@components/Popup/type';
+
+interface ContentsProps {
+  label: string;
+  popupData: IPopupData;
+}
+
+export default function Contents({ label, popupData }: ContentsProps) {
+  return (
+    <div className="filter__item-wrapper">
+      <div className="filter__item">{getModalItem(label, popupData)}</div>
+      <div className="filter__check">
+        <I.Circle.Check />
+      </div>
+    </div>
+  );
+}

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
 
-export const getModalItem = (label: string, popupData: any) => {
+import { IPopupData } from '@components/Popup/type';
+
+export const getModalItem = (label: string, popupData: IPopupData) => {
   switch (label) {
     case '이슈':
       return <div id={popupData.status}>{popupData.name}</div>;

--- a/FE/src/components/Popup/type.ts
+++ b/FE/src/components/Popup/type.ts
@@ -1,0 +1,7 @@
+export interface IPopupData {
+  id: number;
+  imageUrl?: string;
+  status?: string;
+  color?: string;
+  name: string;
+}

--- a/FE/src/hooks/useComponentVisible.jsx
+++ b/FE/src/hooks/useComponentVisible.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 
-export default function useComponentVisible(initialIsVisible, callback) {
+export default function useComponentVisible(initialIsVisible) {
   const [isComponentVisible, setIsComponentVisible] =
     useState(initialIsVisible);
   const ref = useRef(null);
@@ -11,7 +11,6 @@ export default function useComponentVisible(initialIsVisible, callback) {
         setIsComponentVisible(false);
       }
       if (e.target.closest('.filter__item-wrapper')) {
-        callback();
         setIsComponentVisible(false);
       }
     }


### PR DESCRIPTION
close #44 #45 

## 🤷‍♂️ Description

타입스크립트에서 any로 타입지정한 부분들 수정하였지만 백엔드 API가 완료된다면 API 기준으로 다시 수정필요, 팝업 로직 분리 작업 진행
팝업에 들어가는 데이터들을 Popup/type.ts 파일 안에 
```typescript
export interface IPopupData {
  id: number;
  imageUrl?: string;
  status?: string;
  color?: string;
  name: string;
}
```
위 형태처럼 물음표 연산자로 데이터들을 막는게 아닌.. 제네릭으로 수정할 순 없을까 고민을 했습니다.

이 부분은 시간나실때 코드 한 번 봐주시면 좋을 것 같습니다!

남은 주말엔 더 추가적으로 기능을 구현하기 보다는 앞으로의 설계를 살짝 생각해보고, 콜라가 작성한 코드를 한 번 훑어 보는 시간을 가질 것 같아요.

## 📝 Primary Commits

- [x] 타입스크립트 타입 지정
- [x] 팝업 로직 분리

