### PR TITLE
[FE][Muffin] 이슈 필터 기능 URL params

### DIFF
--- a/FE/src/components/FilterBar/index.tsx
+++ b/FE/src/components/FilterBar/index.tsx
@@ -13,9 +13,9 @@ export default function FilterBar() {
   const issueFilterData = {
     info: [
       { id: 1, status: 'is:open', name: '열린이슈' },
-      { id: 2, status: 'mine:@me', name: '내가작성한이슈' },
-      { id: 3, status: 'assignedToMe:@me', name: '나에게할당된이슈' },
-      { id: 4, status: 'comment:@me', name: '내가댓글을남긴이슈' },
+      { id: 2, status: 'mine@me', name: '내가작성한이슈' },
+      { id: 3, status: 'assignedToMe@me', name: '나에게할당된이슈' },
+      { id: 4, status: 'comment@me', name: '내가댓글을남긴이슈' },
       { id: 5, status: 'is:close', name: '닫힌이슈' },
     ],
   };
@@ -23,8 +23,7 @@ export default function FilterBar() {
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
 
-  // TODO 차후에 수정필요 replace 함수 대신 다른 함수로 작업
-  const { replace } = useSearch('q', 'is:open');
+  const { init } = useSearch('q', 'is:open');
 
   const handleOnFilterPopup = () => {
     setIsComponentVisible(true);
@@ -35,7 +34,7 @@ export default function FilterBar() {
     popupData: IPopupData,
   ) => {
     e.stopPropagation();
-    replace(popupData.status, popupData.name);
+    init({ paramValue: popupData.status });
     setIsComponentVisible(false);
   };
 

--- a/FE/src/components/Issue/index.tsx
+++ b/FE/src/components/Issue/index.tsx
@@ -1,4 +1,6 @@
+import { useState, useEffect } from 'react';
 import { useQuery } from 'react-query';
+import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import { IssueWrapperLayer } from './style';
@@ -9,6 +11,10 @@ import { issueState } from '@recoil/atoms/issue';
 
 export default function Issue() {
   const [issue, setIssue] = useRecoilState(issueState);
+  const [renderIssue, setRenderIssue] = useState(
+    issue.filter(is => is.status === 'open'),
+  );
+  const location = useLocation();
 
   useQuery('issueData', () => {
     fetch('issue').then(res => {
@@ -18,11 +24,35 @@ export default function Issue() {
     });
   });
 
+  useEffect(() => {
+    const urlSearch = decodeURI(decodeURIComponent(location.search));
+    const params = new URLSearchParams(urlSearch);
+    const key = params.get('q');
+
+    switch (key) {
+      case 'is:open':
+      case null:
+        setRenderIssue(issue.filter(is => is.status === 'open'));
+        break;
+      case 'mine@me':
+        break;
+      case 'assignedToMe@me':
+        break;
+      case 'comment@me':
+        break;
+      case 'is:close':
+        setRenderIssue(issue.filter(is => is.status === 'close'));
+        break;
+      default:
+        throw Error('key not found');
+    }
+  }, [issue, location]);
+
   return (
     <IssueWrapperLayer>
       <Navigation />
-      {issue &&
-        issue.map(issueData => (
+      {renderIssue &&
+        renderIssue.map(issueData => (
           <Item issue={issueData} key={`issue-${issueData.id}`} />
         ))}
     </IssueWrapperLayer>

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -32,7 +32,7 @@ const getIssue = rest.get('/issue', (req, res, ctx) =>
       {
         id: 2,
         number: 5, // 이슈 고유값
-        status: 'open',
+        status: 'close',
         title: '이슈 페이지 기능 작업',
         manager: ['muffin', 'cola'],
         labels: ['feat', 'sub', 'bug'],


### PR DESCRIPTION
## 🤷‍♂️ Description

만들어주신 useSearch hooks init 함수를 사용해서 이슈 필터바 선택시 params가 바뀌고 바뀐 params를 이슈 컴포넌트에서 가져와서 switch-case문으로 분리하여 open 데이터랑 close데이터 이슈페이지에 뿌려보았습니다.

백엔드 API가 어떻게 올지몰라서 우선 크게 임의적으로 저희가 만든 issueFilterData의 status 값들에 대해선 크게 고민하지 않았어요!

useEffect가 처음 페이지 로드시에도 동작되기 때문에, 아무런 값이 오지 않을때 에러가나서 우선은 null처리도 case문에 할당해주었는데 이 부분 수정이 필요할 것 같아요ㅎㅎ..

변하지 않고 기존 초기 데이터를 저장하는 issue와, 화면에 계속해서 뿌려줄 renderIssue를 useState로 만들었어요. 
이게 필터할때마다 api요청을 보내는건 아닌 것 같아서.. 저희쪽에서 기존데이터를 계속 파싱하는게 맞다고? 생각이 들었습니다.

다음은 네비게이션 바에 있는 담당자 레이블 마일스톤 작성자 팝업에 대해서도 작업 해볼게요
(테스트 코드는.. 기능부터 좀 하고 주말에 다시 만져보려구요)


## 📝 Primary Commits

- [x] useSearch 함수 init 함수를 사용하여 URL 셋팅
- [x] Issue component 에서 URL param 가져와서 셋팅
- [x] open, close 선택 시 각 status에 맞는 이슈를 필터하여 이슈영역에 뿌려주기