### PR TITLE
[FE][Muffin] 팝업 Url Param 추가 기능구현

### DIFF
--- a/FE/src/components/FilterBar/index.tsx
+++ b/FE/src/components/FilterBar/index.tsx
@@ -13,9 +13,9 @@ export default function FilterBar() {
   const issueFilterData = {
     info: [
       { id: 1, status: 'is:open', name: '열린이슈' },
-      { id: 2, status: 'mine@me', name: '내가작성한이슈' },
-      { id: 3, status: 'assignedToMe@me', name: '나에게할당된이슈' },
-      { id: 4, status: 'comment@me', name: '내가댓글을남긴이슈' },
+      { id: 2, status: 'mine:me', name: '내가작성한이슈' },
+      { id: 3, status: 'assignedToMe:me', name: '나에게할당된이슈' },
+      { id: 4, status: 'comment:me', name: '내가댓글을남긴이슈' },
       { id: 5, status: 'is:close', name: '닫힌이슈' },
     ],
   };

--- a/FE/src/components/Issue/Filter/index.tsx
+++ b/FE/src/components/Issue/Filter/index.tsx
@@ -28,14 +28,14 @@ export default function Filter({
     handleFilterClick(label, true);
     setIsComponentVisible(!isComponentVisible);
   };
-  const { replace } = useSearch('q', 'is:open');
+  const { replace } = useSearch('q', '');
 
   const handleItemClick = (
     e: React.MouseEvent<HTMLElement>,
     popupData: IPopupData,
   ) => {
     e.stopPropagation();
-    replace(popupData.status, popupData.name);
+    replace(label, popupData.name);
     setIsComponentVisible(false);
   };
 

--- a/FE/src/components/Issue/Item/index.tsx
+++ b/FE/src/components/Issue/Item/index.tsx
@@ -17,9 +17,15 @@ interface IIssueItem {
   title: string;
 }
 
-export default function Item({ issue }: { issue: IIssueItem }) {
+export default function Item({
+  issue,
+  lastIdx,
+}: {
+  issue: IIssueItem;
+  lastIdx?: boolean;
+}) {
   return (
-    <ItemLayer>
+    <ItemLayer lastIdx={lastIdx}>
       <I.CheckBox.Initial color="#D9DBE9" />
       <ContentLayer>
         <div>
@@ -28,7 +34,7 @@ export default function Item({ issue }: { issue: IIssueItem }) {
         </div>
         <div>
           <Description>#{issue.number}</Description>
-          {/* <Description>{issue.author[0].name}</Description> */}
+          <Description>{issue.author[0].name}</Description>
           <I.MileStone /> <Description>{issue.milestone}</Description>
         </div>
         <div

--- a/FE/src/components/Issue/Item/style.ts
+++ b/FE/src/components/Issue/Item/style.ts
@@ -8,6 +8,8 @@ export const ItemLayer = styled.div`
   background-color: ${({ theme }) => theme.color.offWhite};
   border-top: 1px solid;
   border-color: ${({ theme }) => theme.color.line};
+  border-radius: ${(props: { lastIdx: any }) =>
+    props.lastIdx ? '0 0 1rem 1rem' : ''};
   ${flexbox({ dir: 'row', jc: 'flex-start', ai: 'flex-start' })};
 `;
 

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -11,14 +11,14 @@ import { issueState } from '@recoil/atoms/issue';
 import { labelState } from '@recoil/atoms/label';
 import { mileStoneState } from '@recoil/atoms/milestone';
 
-export type FilterLabelTypes = '담당자' | '레이블' | '마일스톤' | '작성자';
+export type FilterLabelTypes = 'assignee' | 'label' | 'mileStone' | 'author';
 
 export default function Navigation() {
   const filterLabels: FilterLabelTypes[] = [
-    '담당자',
-    '레이블',
-    '마일스톤',
-    '작성자',
+    'assignee',
+    'label',
+    'mileStone',
+    'author',
   ];
 
   const assigneeData = useRecoilValue(assigneeState);
@@ -29,17 +29,17 @@ export default function Navigation() {
   const [issues, setIssues] = useRecoilState(issueState);
 
   const [popupState, setPopupState] = useState({
-    담당자: false,
-    레이블: false,
-    마일스톤: false,
-    작성자: false,
+    assignee: false,
+    label: false,
+    mileStone: false,
+    author: false,
   });
 
   const [filterPopupData, setFilterPoupData] = useState({
-    담당자: assigneeData,
-    레이블: labelData,
-    마일스톤: milestoneData,
-    작성자: authorData,
+    assignee: assigneeData,
+    label: labelData,
+    mileStone: milestoneData,
+    author: authorData,
   });
 
   const [labelIssueStatus, setLabelIssueStatus] = useState({

--- a/FE/src/components/Issue/index.tsx
+++ b/FE/src/components/Issue/index.tsx
@@ -7,19 +7,24 @@ import { IssueWrapperLayer } from './style';
 
 import Item from '@components/Issue/Item';
 import Navigation from '@components/Issue/Navigation';
-import { issueState } from '@recoil/atoms/issue';
+import { IIssueTypes, issueState } from '@recoil/atoms/issue';
+
+interface IKeyParams {
+  [key: string]: string;
+}
 
 export default function Issue() {
-  const [issue, setIssue] = useRecoilState(issueState);
-  const [renderIssue, setRenderIssue] = useState(
-    issue.filter(is => is.status === 'open'),
-  );
+  const [initIssue, setInitIssue] = useRecoilState(issueState);
+  const [renderIssue, setRenderIssue] = useState<IIssueTypes[]>([]);
   const location = useLocation();
 
   useQuery('issueData', () => {
     fetch('issue').then(res => {
       res.json().then(result => {
-        setIssue(result);
+        setInitIssue(result);
+        setRenderIssue(
+          result.filter((issue: IIssueTypes) => issue.status === 'open'),
+        );
       });
     });
   });
@@ -28,12 +33,15 @@ export default function Issue() {
     const urlSearch = decodeURI(decodeURIComponent(location.search));
     const params = new URLSearchParams(urlSearch);
     const urlValues = params.get('q');
+
+    if (urlValues === null) return;
+
     const parsingUrlValue = urlValues?.split(' ').map(v => v);
 
     // 스페이스바 기준으로 나눠진 데이터들 중 다시 sep(:) split =>  Key, value를 담는 배열로 나누는 함수 제작
     // 뽑은 key, value를 넘겨 기존 issueData를 필터하는 함수 제작
     const filterDataArray = parsingUrlValue?.map(data => {
-      const obj = {};
+      const obj: IKeyParams = {};
       const [key, value] = data.split(':');
       obj[key] = value;
       return obj;
@@ -43,9 +51,12 @@ export default function Issue() {
     filterDataArray?.forEach(arr => {
       const key = Object.keys(arr)[0];
       const value = Object.values(arr)[0];
+
       switch (key) {
         case 'is':
-          setRenderIssue(issue.filter(is => is.status === value));
+          setRenderIssue(
+            initIssue.filter((issue: IIssueTypes) => issue.status === value),
+          );
           break;
         case 'mine':
           break;
@@ -65,13 +76,13 @@ export default function Issue() {
           console.log(urlValues);
       }
     });
-  }, [issue, location]);
+  }, [initIssue, location]);
 
   return (
     <IssueWrapperLayer>
       <Navigation />
       {renderIssue &&
-        renderIssue.map((issueData, index) => (
+        renderIssue.map((issueData: IIssueTypes, index: number) => (
           <Item
             issue={issueData}
             lastIdx={renderIssue.length === index + 1}

--- a/FE/src/components/Issue/index.tsx
+++ b/FE/src/components/Issue/index.tsx
@@ -27,33 +27,56 @@ export default function Issue() {
   useEffect(() => {
     const urlSearch = decodeURI(decodeURIComponent(location.search));
     const params = new URLSearchParams(urlSearch);
-    const key = params.get('q');
+    const urlValues = params.get('q');
+    const parsingUrlValue = urlValues?.split(' ').map(v => v);
 
-    switch (key) {
-      case 'is:open':
-      case null:
-        setRenderIssue(issue.filter(is => is.status === 'open'));
-        break;
-      case 'mine@me':
-        break;
-      case 'assignedToMe@me':
-        break;
-      case 'comment@me':
-        break;
-      case 'is:close':
-        setRenderIssue(issue.filter(is => is.status === 'close'));
-        break;
-      default:
-        throw Error('key not found');
-    }
+    // 스페이스바 기준으로 나눠진 데이터들 중 다시 sep(:) split =>  Key, value를 담는 배열로 나누는 함수 제작
+    // 뽑은 key, value를 넘겨 기존 issueData를 필터하는 함수 제작
+    const filterDataArray = parsingUrlValue?.map(data => {
+      const obj = {};
+      const [key, value] = data.split(':');
+      obj[key] = value;
+      return obj;
+    });
+
+    // 백엔드 API가 완성되면 이부분 함수 분리 + 로직 재작성
+    filterDataArray?.forEach(arr => {
+      const key = Object.keys(arr)[0];
+      const value = Object.values(arr)[0];
+      switch (key) {
+        case 'is':
+          setRenderIssue(issue.filter(is => is.status === value));
+          break;
+        case 'mine':
+          break;
+        case 'assignedToMe':
+          break;
+        case 'comment':
+          break;
+        case 'assignee':
+          break;
+        case 'label':
+          break;
+        case 'mileStone':
+          break;
+        case 'author':
+          break;
+        default:
+          console.log(urlValues);
+      }
+    });
   }, [issue, location]);
 
   return (
     <IssueWrapperLayer>
       <Navigation />
       {renderIssue &&
-        renderIssue.map(issueData => (
-          <Item issue={issueData} key={`issue-${issueData.id}`} />
+        renderIssue.map((issueData, index) => (
+          <Item
+            issue={issueData}
+            lastIdx={renderIssue.length === index + 1}
+            key={`issue-${issueData.id}`}
+          />
         ))}
     </IssueWrapperLayer>
   );

--- a/FE/src/components/Issue/style.ts
+++ b/FE/src/components/Issue/style.ts
@@ -5,5 +5,4 @@ export const IssueWrapperLayer = styled.section`
   border: 1px solid;
   border-radius: 1rem;
   border-color: ${({ theme }) => theme.color.line};
-  overflow: hidden;
 `;

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -6,8 +6,8 @@ export const getModalItem = (label: string, popupData: IPopupData) => {
   switch (label) {
     case '이슈':
       return <div id={popupData.status}>{popupData.name}</div>;
-    case '담당자':
-    case '작성자':
+    case 'author':
+    case 'assignee':
       return (
         <>
           <div
@@ -22,7 +22,7 @@ export const getModalItem = (label: string, popupData: IPopupData) => {
           <div className="filter__name">{popupData.name}</div>
         </>
       );
-    case '레이블':
+    case 'label':
       return (
         <>
           <div
@@ -37,7 +37,7 @@ export const getModalItem = (label: string, popupData: IPopupData) => {
           <div className="filter__name">{popupData.name}</div>
         </>
       );
-    case '마일스톤':
+    case 'mileStone':
       return <div className="filter__name">{popupData.name}</div>;
     default:
       throw Error('label type not found');

--- a/FE/src/components/Popup/style.tsx
+++ b/FE/src/components/Popup/style.tsx
@@ -19,7 +19,7 @@ export const FilterPopup = styled.div`
   min-height: 2.75rem;
   border-radius: 1rem;
   border: 1px solid ${({ theme }) => theme.color.line};
-  z-index: 10;
+  z-index: ${({ theme }) => theme.zIndex.header};
   overflow: hidden;
   box-shadow: 0 0.5rem 1.5rem ${({ theme }) => theme.color.line};
   animation: ${moveDownAnimation} 300ms ease;

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -33,10 +33,21 @@ const getIssue = rest.get('/issue', (req, res, ctx) =>
         id: 2,
         number: 5, // 이슈 고유값
         status: 'close',
-        title: '이슈 페이지 기능 작업',
+        title: '로그인 기능 작업',
         manager: ['muffin', 'cola'],
         labels: ['feat', 'sub', 'bug'],
-        milestone: '1주차 이슈트래커',
+        milestone: '2주차 이슈트래커',
+        author: [{ name: 'cola', iamgeUrl: 'http://xxx' }],
+        date: '2022-12-17T03:24:00',
+      },
+      {
+        id: 3,
+        number: 2, // 이슈 고유값
+        status: 'close',
+        title: '리팩토링 작업',
+        manager: ['muffin', 'cola'],
+        labels: ['feat', 'sub', 'bug'],
+        milestone: '3주차 이슈트래커',
         author: [{ name: 'muffin', iamgeUrl: 'http://xxx' }],
         date: '2022-12-17T03:24:00',
       },

--- a/FE/src/recoil/atoms/label.ts
+++ b/FE/src/recoil/atoms/label.ts
@@ -13,12 +13,12 @@ export const labelState = atom<{ info: ILabelTypes[] }>({
       {
         id: 1,
         color: '#000000',
-        name: 'cola',
+        name: 'colaLabel',
       },
       {
         id: 2,
         color: '#0025E7',
-        name: 'muffin',
+        name: 'muffinLabel',
       },
     ],
   },

--- a/FE/src/recoil/atoms/milestone.ts
+++ b/FE/src/recoil/atoms/milestone.ts
@@ -11,11 +11,11 @@ export const mileStoneState = atom<{ info: IMileStoneTypes[] }>({
     info: [
       {
         id: 1,
-        name: '1주차 마일스톤',
+        name: 'muffinMileStone',
       },
       {
         id: 2,
-        name: '2주차 마일스톤',
+        name: 'colaMileStone',
       },
     ],
   },


### PR DESCRIPTION
## 🤷‍♂️ Description

이슈 필터와 비슷하게 네비게이션 바 내의 팝업들도 useSearch의 replace 함수를 가져와서 urlparam을 셋팅하는 작업을 진행하였습니다.
내가 선택한 urlParam에 담긴 값들을 빼와서 어떻게 처리할지 주석에도 적긴했는데.. 다시 글로 정리해볼게요

1. 스페이스바 기준으로 데이터를 먼저 나눕니다. =>  ['is:open', 'assignee:assignee1', 'author:cola']
2. 나눠진 데이터에서 sep(:) split =>  Key, value 객체 형태로 filterDataArray 변수에 담았습니다.
3. filterDataArray를 전부 돌면서 key(is, mine, assignedToMe, comment, assignee, label, mileStone, author)에 따라 value를 필터
링하도록 하였습니다.

<img width="675" alt="4글자이상" src="https://user-images.githubusercontent.com/45479309/175235203-dd051add-c014-49bf-bf9e-1f69e6eeef72.png">

replace 함수에 popupData.name(label, mileStone, author, asignee는 모두 동일한 데이터를 가지도록 설정함)를 넣을때 4글자 이상? 한글이 들어가면 갑자기 제대로 파싱이 되지 않는것 같은데 이게 디버깅 하나하나 찍어봐도 왜그런지 잘 모르겠네요ㅠ.ㅠ

백엔드 이슈페이지  API가 오기전까지, 우선 레이블 페이지를 이어가도록 할게요!
