### PR TITLE
[FE][Cola] Textarea 컴포넌트 UI 구현

### DIFF
--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'react/prop-types': 'off',
     'no-nested-ternary': 'off',
     'react/function-component-definition': 'off',
+    'jsx-a11y/label-has-associated-control': 'off',
     'import/order': [
       'error',
       {

--- a/FE/src/components/Input/index.tsx
+++ b/FE/src/components/Input/index.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 import * as S from './style';
 
-import { CombineElementProps } from '@utils/types';
+import I from '@components/Icons';
+import { OverridableProps } from '@utils/types';
 
-type InputProps<T extends React.ElementType> = CombineElementProps<
+type InputProps<T extends React.ElementType> = OverridableProps<
   T,
   {
     width: number;
@@ -39,3 +40,48 @@ export const Input = <T extends React.ElementType = 'input'>({
     <S.PlaceHolder>{placeholder}</S.PlaceHolder>
   </S.InputLayer>
 );
+
+export const Textarea = <T extends React.ElementType = 'input'>({
+  width,
+  placeholder,
+  value = '',
+  disabled = false,
+  ...restProps
+}: InputProps<T>) => {
+  const id = useId();
+
+  return (
+    <S.TextareaLayer
+      width={width}
+      size="md"
+      disabled={disabled}
+      active={!!value.length}
+    >
+      <S.Textarea
+        width={width}
+        as="textarea"
+        value={value}
+        disabled={disabled}
+        {...restProps}
+      />
+
+      {/* TODO: 파일 첨부하기 부분을 Props로 */}
+      {/* TODO: 이미지만 업로드받기 */}
+      {/* TODO: 2초간 보여줄 문자열 */}
+
+      <S.PlaceHolder>{placeholder || '코멘트를 입력하세요'}</S.PlaceHolder>
+      <S.WordCount>띄어쓰기 </S.WordCount>
+      <S.Footer>
+        <S.Label htmlFor={id}>
+          {undefined || (
+            <>
+              <I.Clip />
+              <span>파일 첨부하기</span>
+            </>
+          )}
+        </S.Label>
+        <input id={id} type="file" accept="image/*" hidden />
+      </S.Footer>
+    </S.TextareaLayer>
+  );
+};

--- a/FE/src/components/Input/style.ts
+++ b/FE/src/components/Input/style.ts
@@ -2,6 +2,38 @@ import styled from '@emotion/styled';
 
 import { typoSmall, inlineFlexbox, typoXSmall } from '@styles/mixin';
 
+export const WordCount = styled.div`
+  ${typoXSmall(400)};
+  color: ${({ theme }) => theme.color.label};
+  position: absolute;
+  bottom: 4.5rem;
+  right: 1.59375rem;
+  pointer-events: none;
+`;
+
+export const Label = styled.label`
+  ${typoXSmall(700)};
+  color: ${({ theme }) => theme.color.label};
+  cursor: pointer;
+  i {
+    margin-right: 0.5rem;
+  }
+`;
+
+export const Footer = styled.footer`
+  height: 3.25rem;
+  background-image: linear-gradient(
+    to right,
+    black 50%,
+    rgba(255, 255, 255, 0) 0%
+  );
+  background-position: top;
+  background-size: 0.5rem 0.8px;
+  background-repeat: repeat-x;
+  padding: 1rem 1.5rem;
+  transition: all 100ms;
+`;
+
 export const PlaceHolder = styled.div`
   ${typoSmall(400)};
   ${inlineFlexbox({ ai: 'center' })};
@@ -13,7 +45,7 @@ export const PlaceHolder = styled.div`
   height: 100%;
   pointer-events: none;
   white-space: nowrap;
-  transition: font-size 100ms, transform 100ms;
+  transition: font-size 150ms, transform 150ms;
 `;
 
 export const Input = styled.input`
@@ -124,4 +156,43 @@ export const InputLayer = styled.div<{
         color: ${theme.color.darkRed};
       };
   `};
+`;
+
+export const Textarea = styled(Input)<{ width: number }>`
+  transition: all 100ms;
+  resize: vertical;
+`;
+
+export const TextareaLayer = styled(InputLayer)`
+  position: relative;
+  flex-direction: column;
+  height: auto;
+  transition: all 100ms;
+
+  ${PlaceHolder} {
+    align-items: flex-start;
+    padding-top: 1rem;
+  }
+
+  ${Textarea} {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    padding-left: 1.7rem;
+    transform: translate3d(-0.2rem, -0.2rem, 0);
+    min-height: 12.5rem;
+    line-height: 1.75;
+  }
+
+  ${({ active }) =>
+    active &&
+    `
+      padding-top: 1.5rem;
+      ${PlaceHolder} {
+        transform: translate3d(0, -1rem, 0);
+      }
+      
+      ${Textarea} {
+        margin-top: 1rem;
+      }
+    `};
 `;


### PR DESCRIPTION
## 📝 Primary Commits
- close #76
- UI까지만 구현했습니다.

더 구현해야 하는 부분
- "파일 첨부" 조건부 렌더링 (업로드시, 업로드 완료시, 초기 상태)
- 파일 첨부시 area에 텍스트 삽입
- 글자 수 세기 기능 (아마 디바운싱으로)
- 이미지만 업로드받기 (html에도 막아두긴 했지만, 모든 파일 누르면 다른 파일도 업로드가 되기 때문에 스크립트로 막아줄 코드 필요)

- 파일첨부 레이어의 border-top 부분은 border style dashed로 처리하지 않고, background로 처리했습니다! (커스터마이징이 좀 더 가능하기 때문에)

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
![z](https://user-images.githubusercontent.com/79135734/175254225-ee37f64d-47cf-4088-b0c2-26d0965d1314.PNG)



<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
