### PR TITLE
[FE-Fix][Muffin] 네비게이션 안에있는 열린이슈, 닫힌 이슈 색상 변경 오류

### DIFF
--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useRecoilValue, useRecoilState } from 'recoil';
 
 import { NavigationLayer, LeftLayer, RightLayer, IssueLabel } from './style';
 
 import I from '@components/Icons';
 import Filter from '@components/Issue/Filter';
+import { useSearch } from '@hooks/useSearch';
 import { assigneeState } from '@recoil/atoms/assignee';
 import { authorState } from '@recoil/atoms/author';
 import { issueState } from '@recoil/atoms/issue';
@@ -14,6 +16,8 @@ import { mileStoneState } from '@recoil/atoms/milestone';
 export type FilterLabelTypes = 'assignee' | 'label' | 'mileStone' | 'author';
 
 export default function Navigation() {
+  const { init } = useSearch('q', 'is:open');
+  const location = useLocation();
   const filterLabels: FilterLabelTypes[] = [
     'assignee',
     'label',
@@ -54,15 +58,11 @@ export default function Navigation() {
 
   const handleLabelClick = (status: string) => {
     if (status === 'open') {
-      setLabelIssueStatus({
-        open: true,
-        close: false,
-      });
+      setLabelIssueStatus({ open: true, close: false });
+      init({ paramValue: 'is:open' });
     } else if (status === 'close') {
-      setLabelIssueStatus({
-        open: false,
-        close: true,
-      });
+      setLabelIssueStatus({ open: false, close: true });
+      init({ paramValue: 'is:close' });
     }
   };
 
@@ -71,6 +71,20 @@ export default function Navigation() {
   };
 
   const onPopup = (label: FilterLabelTypes) => !!popupState[label];
+
+  useEffect(() => {
+    const urlSearch = decodeURI(decodeURIComponent(location.search));
+    const params = new URLSearchParams(urlSearch);
+    const urlValues = params.get('q');
+
+    if (urlValues === null) return;
+
+    if (urlValues === 'is:open') {
+      setLabelIssueStatus({ open: true, close: false });
+    } else if (urlValues === 'is:close') {
+      setLabelIssueStatus({ open: false, close: true });
+    }
+  }, [location]);
 
   return (
     <NavigationLayer>


### PR DESCRIPTION
## 🤷‍♂️ Description

필터 관련 부분 보다가 이슈 메인페이지 약간의 오류를 발견하여 해당 부분 약간 수정하였습니다.
이슈 필터에서 열린이슈 닫힌이슈 클릭시 네비게이션 안에있는 열린이슈, 닫힌이슈 색상도 url 값에 따라 변경되도록 추가

우선은 useEffect 함수내에서 조건처리 했는데 백엔드 api가 확정되면 여기도 변수명 수정이 필요할 것 같아요!