### PR TITLE
[FE][Muffin] 레이블 페이지 기능 작업 진행

### DIFF
--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -34,6 +34,8 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': 'off',
     'no-use-before-define': 'off',
     'jsx-a11y/control-has-associated-label': 'off',
+    'react-hooks/rules-of-hooks': 'off',
+
     'import/order': [
       'error',
       {

--- a/FE/.eslintrc.js
+++ b/FE/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     'react/function-component-definition': 'off',
     'jsx-a11y/label-has-associated-control': 'off',
     'no-use-before-define': 'off',
+    'jsx-a11y/control-has-associated-label': 'off',
     'import/order': [
       'error',
       {

--- a/FE/public/index.html
+++ b/FE/public/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/FE/src/components/Label/Form.tsx
+++ b/FE/src/components/Label/Form.tsx
@@ -16,6 +16,7 @@ import {
   defaultBgColors,
 } from '@constants/default';
 import useComponentVisible from '@hooks/useComponentVisible';
+import { ILabelTypes } from '@recoil/atoms/label';
 import { typoXSmall, flexbox } from '@styles/mixin';
 import theme from '@styles/theme';
 
@@ -44,9 +45,13 @@ export default function Form({
 
   const handleBgColor = () => {
     // 랜덤 컬러 색상 만드는 함수
-    const randomColor = `#${Math.round(Math.random() * 0xffffff)
-      .toString(16)
-      .toUpperCase()}`;
+    const randomColor = new Array(3).fill(0).reduce((prev: string) => {
+      prev += Math.floor(Math.random() * 127 + 128)
+        .toString(16)
+        .toUpperCase();
+      return prev;
+    }, '#');
+
     setBgColor(randomColor);
   };
 
@@ -70,7 +75,7 @@ export default function Form({
     setIsComponentVisible(false);
   };
 
-  const createLabelPost = useMutation((newLabel: any) =>
+  const createLabelPost = useMutation((newLabel: ILabelTypes) =>
     fetch('/issue/label', {
       method: 'POST',
       body: JSON.stringify(newLabel),
@@ -79,9 +84,9 @@ export default function Form({
 
   const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // api 요청
 
     const newLabel = {
+      id: 3,
       title: labelText,
       description: descriptionText,
       backgroundColor: bgColor,

--- a/FE/src/components/Label/Form.tsx
+++ b/FE/src/components/Label/Form.tsx
@@ -20,20 +20,34 @@ import { ILabelTypes } from '@recoil/atoms/label';
 import { typoXSmall, flexbox } from '@styles/mixin';
 import theme from '@styles/theme';
 
+interface FormProps {
+  title: string;
+  labelData?: ILabelTypes;
+  onEdit: boolean;
+  handleCloseForm: (id?: number) => void;
+}
+
 export default function Form({
   title,
-  setOpenForm,
-}: {
-  title: string;
-  setOpenForm: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
+  labelData,
+  onEdit,
+  handleCloseForm,
+}: FormProps) {
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
 
-  const [labelText, setLabelText] = useState('');
-  const [descriptionText, setDescriptionText] = useState('');
-  const [bgColor, setBgColor] = useState(initBgColor);
-  const [radioState, setRadioState] = useState(radioColorText[0]);
+  const [labelText, setLabelText] = useState(labelData?.title || '');
+  const [descriptionText, setDescriptionText] = useState(
+    labelData?.description || '',
+  );
+  const [bgColor, setBgColor] = useState(
+    labelData?.backgroundColor || initBgColor,
+  );
+  const [radioState, setRadioState] = useState(
+    labelData?.textColor === 'BLACK'
+      ? '어두운색'
+      : '밝은색' || radioColorText[0],
+  );
 
   const handleLabelText = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLabelText(e.target.value);
@@ -100,9 +114,9 @@ export default function Form({
     // 임시로 응답이 정상적으로 왔을때 처리 차후는 Persist mutation 적용필요
     if (createLabelPost.isSuccess) {
       alert('label add success');
-      setOpenForm(false);
+      handleCloseForm();
     }
-  }, [createLabelPost, setOpenForm]);
+  }, [createLabelPost, handleCloseForm]);
 
   return (
     <S.FormWrapper title={title} onSubmit={handleSubmit}>
@@ -207,13 +221,36 @@ export default function Form({
           </S.FormInnerWrapper>
         </S.FormRightInner>
         <S.FormButtonWrapper>
-          <Button
-            type="submit"
-            disabled={labelText === '' || bgColor === '' || radioState === ''}
-          >
-            <I.Plus />
-            완료
-          </Button>
+          {onEdit ? (
+            <>
+              <Button
+                outlined
+                css={css`
+                  margin-right: 1rem;
+                `}
+                onClick={() => handleCloseForm(labelData?.id)}
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  labelText === '' || bgColor === '' || radioState === ''
+                }
+              >
+                <I.Edit />
+                완료
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="submit"
+              disabled={labelText === '' || bgColor === '' || radioState === ''}
+            >
+              <I.Plus />
+              완료
+            </Button>
+          )}
         </S.FormButtonWrapper>
       </S.FormContents>
     </S.FormWrapper>

--- a/FE/src/components/Label/Form.tsx
+++ b/FE/src/components/Label/Form.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { useState } from 'react';
 
 import * as S from './formStyle';
@@ -6,17 +7,39 @@ import { Button } from '@components/Button';
 import I from '@components/Icons';
 import { Input } from '@components/Input';
 import { Label } from '@components/Label';
+import Popup from '@components/Popup';
 import RadioSelection from '@components/RadioSelection';
+import useComponentVisible from '@hooks/useComponentVisible.jsx';
+import { typoXSmall, flexbox } from '@styles/mixin';
+import theme from '@styles/theme';
 
 export default function Form({ title }: { title: string }) {
+  const radioColorText = ['어두운색', '밝은색'];
+  const defaultColors = [
+    '#B60205',
+    '#D93F0B',
+    '#FBCA04',
+    '#0E8A16',
+    '#006B75',
+    '#1D76DB',
+    '#0052CC',
+    '#5319E7',
+    '#E99695',
+    '#F9D0C4',
+    '#FEF2C0',
+    '#C2E0C6',
+    '#BFDADC',
+    '#C5DEF5',
+    '#BFD4F2',
+    '#D4C5F9',
+  ];
+  const { ref, isComponentVisible, setIsComponentVisible } =
+    useComponentVisible(false);
+
   const [labelText, setLabelText] = useState('');
   const [descriptionText, setDescriptionText] = useState('');
   const [bgColor, setBgColor] = useState('#EFF0F6');
-  const [colorText, setColorText] = useState({
-    darkColor: true,
-    whiteColor: false,
-  });
-  const [complelteBtn, setComplelteBtn] = useState(false);
+  const [radioState, setRadioState] = useState('어두운색');
 
   const handleLabelText = (e: React.ChangeEvent<HTMLInputElement>) => {
     setLabelText(e.target.value);
@@ -27,11 +50,31 @@ export default function Form({ title }: { title: string }) {
   };
 
   const handleBgColor = (e: React.MouseEvent<HTMLElement>) => {
-    setBgColor('#000000');
+    // 랜덤 컬러 색상 만드는 함수
+    const randomColor = `#${Math.round(Math.random() * 0xffffff)
+      .toString(16)
+      .toUpperCase()}`;
+    setBgColor(randomColor);
   };
 
-  const handleColorText = (e: any) => {
-    console.log(e.target);
+  const handleColorText = (color: string) => {
+    setRadioState(color);
+  };
+
+  const onColorPopup = () => {
+    setIsComponentVisible(true);
+  };
+
+  const onChangeColor = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value === '') e.target.value = '#';
+    setBgColor(e.target.value);
+  };
+
+  const handleColorClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    e.stopPropagation();
+    setBgColor(button.value);
+    setIsComponentVisible(false);
   };
 
   return (
@@ -69,23 +112,81 @@ export default function Form({ title }: { title: string }) {
                 value={bgColor || ''}
                 width={240}
                 placeholder="배경 색상"
+                onClick={onColorPopup}
+                onChange={onChangeColor}
+                maxLength={7}
               />
               <S.RefreshButton type="button" onClick={handleBgColor}>
-                <I.Refresh color="#6E7191" />
+                <I.Refresh color={bgColor} />
               </S.RefreshButton>
+              <div
+                ref={ref}
+                css={css`
+                  position: absolute;
+                  left: 0;
+                  top: 3rem;
+                `}
+              >
+                {isComponentVisible && (
+                  <Popup>
+                    <div
+                      css={css`
+                        margin-top: 1rem;
+                        padding: 0 1rem;
+                        ${typoXSmall(400)}
+                        ${flexbox({ ai: 'center' })}
+                      `}
+                    >
+                      Choose from default colors
+                    </div>
+                    <div
+                      css={css`
+                        padding: 0.5rem 1rem;
+                        background-color: ${theme.color.offWhite};
+                        color: ${theme.color.line};
+                        ${flexbox({ ai: 'center' })}
+                        gap: 2px;
+                        flex-wrap: wrap;
+                      `}
+                    >
+                      {defaultColors.map(color => (
+                        <button
+                          type="button"
+                          key={color}
+                          value={color}
+                          css={css`
+                            width: 1.5rem;
+                            height: 1.5rem;
+                            border-radius: 5px;
+                            background-color: ${color};
+                            cursor: pointer;
+                          `}
+                          onClick={handleColorClick}
+                        />
+                      ))}
+                    </div>
+                  </Popup>
+                )}
+              </div>
             </S.ColorWrapper>
             <RadioSelection.Container title="텍스트 색상">
-              <RadioSelection.Option checked onClick={handleColorText}>
-                어두운 색
-              </RadioSelection.Option>
-              <RadioSelection.Option onClick={handleColorText}>
-                밝은 색
-              </RadioSelection.Option>
+              {radioColorText.map((radioColor: string) => (
+                <RadioSelection.Option
+                  key={radioColor}
+                  checked={radioState === radioColor}
+                  onClick={() => handleColorText(radioColor)}
+                >
+                  {radioColor}
+                </RadioSelection.Option>
+              ))}
             </RadioSelection.Container>
           </S.FormInnerWrapper>
         </S.FormRightInner>
         <S.FormButtonWrapper>
-          <Button disabled={!complelteBtn}>
+          <Button
+            type="button"
+            disabled={labelText === '' || bgColor === '' || radioState === ''}
+          >
             <I.Plus />
             완료
           </Button>

--- a/FE/src/components/Label/Form.tsx
+++ b/FE/src/components/Label/Form.tsx
@@ -36,41 +36,58 @@ export default function Form({
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
 
-  const [labelText, setLabelText] = useState(labelData?.title || '');
-  const [descriptionText, setDescriptionText] = useState(
-    labelData?.description || '',
-  );
-  const [bgColor, setBgColor] = useState(
-    labelData?.backgroundColor || initBgColor,
-  );
-  const [radioState, setRadioState] = useState(
-    labelData?.textColor === 'BLACK'
-      ? '어두운색'
-      : '밝은색' || radioColorText[0],
-  );
+  const [openFormValue, setOpenFormValue] = useState({
+    labelText: labelData?.title || '',
+    descriptionText: labelData?.description || '',
+    bgColor: labelData?.backgroundColor || initBgColor,
+    radioState:
+      labelData?.textColor === 'BLACK'
+        ? '어두운색'
+        : '밝은색' || radioColorText[0],
+  });
+
+  const [initFormValue, setInitFormValue] = useState({
+    labelText: openFormValue.labelText,
+    descriptionText: openFormValue.descriptionText,
+    bgColor: openFormValue.bgColor,
+    radioState: openFormValue.radioState,
+  });
 
   const handleLabelText = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLabelText(e.target.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      labelText: e.target.value,
+    }));
   };
 
   const handleDescriptionText = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDescriptionText(e.target.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      descriptionText: e.target.value,
+    }));
   };
 
   const handleBgColor = () => {
     // 랜덤 컬러 색상 만드는 함수
     const randomColor = new Array(3).fill(0).reduce((prev: string) => {
+      // eslint-disable-next-line no-param-reassign
       prev += Math.floor(Math.random() * 127 + 128)
         .toString(16)
         .toUpperCase();
       return prev;
     }, '#');
 
-    setBgColor(randomColor);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: randomColor,
+    }));
   };
 
   const handleColorText = (color: string) => {
-    setRadioState(color);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      radioState: color,
+    }));
   };
 
   const onColorPopup = () => {
@@ -79,13 +96,19 @@ export default function Form({
 
   const onChangeColor = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value === '') e.target.value = '#';
-    setBgColor(e.target.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: e.target.value,
+    }));
   };
 
   const handleColorClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
     e.stopPropagation();
-    setBgColor(button.value);
+    setOpenFormValue(prevState => ({
+      ...prevState,
+      bgColor: button.value,
+    }));
     setIsComponentVisible(false);
   };
 
@@ -101,10 +124,10 @@ export default function Form({
 
     const newLabel = {
       id: 3,
-      title: labelText,
-      description: descriptionText,
-      backgroundColor: bgColor,
-      textColor: radioState === '어두운색' ? 'BLACK' : 'WHITE',
+      title: openFormValue.labelText,
+      description: openFormValue.descriptionText,
+      backgroundColor: openFormValue.bgColor,
+      textColor: openFormValue.radioState === '어두운색' ? 'BLACK' : 'WHITE',
     };
 
     createLabelPost.mutate(newLabel);
@@ -132,14 +155,14 @@ export default function Form({
           <Input
             type="text"
             width={904}
-            value={labelText || ''}
+            value={openFormValue.labelText || ''}
             placeholder="레이블 이름"
             onChange={handleLabelText}
           />
           <Input
             type="text"
             width={904}
-            value={descriptionText || ''}
+            value={openFormValue.descriptionText || ''}
             placeholder="설명(선택)"
             onChange={handleDescriptionText}
           />
@@ -147,7 +170,7 @@ export default function Form({
             <S.ColorWrapper>
               <Input
                 type="text"
-                value={bgColor || ''}
+                value={openFormValue.bgColor || ''}
                 width={240}
                 placeholder="배경 색상"
                 onClick={onColorPopup}
@@ -155,7 +178,7 @@ export default function Form({
                 maxLength={7}
               />
               <S.RefreshButton type="button" onClick={handleBgColor}>
-                <I.Refresh color={bgColor} />
+                <I.Refresh color={openFormValue.bgColor} />
               </S.RefreshButton>
               <div
                 ref={ref}
@@ -211,7 +234,7 @@ export default function Form({
               {radioColorText.map((radioColor: string) => (
                 <RadioSelection.Option
                   key={radioColor}
-                  checked={radioState === radioColor}
+                  checked={openFormValue.radioState === radioColor}
                   onClick={() => handleColorText(radioColor)}
                 >
                   {radioColor}
@@ -235,7 +258,11 @@ export default function Form({
               <Button
                 type="submit"
                 disabled={
-                  labelText === '' || bgColor === '' || radioState === ''
+                  initFormValue.labelText === openFormValue.labelText &&
+                  initFormValue.bgColor === openFormValue.bgColor &&
+                  initFormValue.descriptionText ===
+                    openFormValue.descriptionText &&
+                  initFormValue.radioState === openFormValue.radioState
                 }
               >
                 <I.Edit />
@@ -245,7 +272,11 @@ export default function Form({
           ) : (
             <Button
               type="submit"
-              disabled={labelText === '' || bgColor === '' || radioState === ''}
+              disabled={
+                openFormValue.labelText === '' ||
+                openFormValue.bgColor === '' ||
+                openFormValue.radioState === ''
+              }
             >
               <I.Plus />
               완료

--- a/FE/src/components/Label/formStyle.ts
+++ b/FE/src/components/Label/formStyle.ts
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { typoLarge, flexbox } from '@styles/mixin';
 import { moveDownAnimation, moveUpAnimation } from '@utils/animation';
 
-export const FormWrapper = styled.div`
+export const FormWrapper = styled.form`
   padding: 2rem;
   margin-bottom: 1.5rem;
   border: 1px solid;

--- a/FE/src/components/Modal/index.tsx
+++ b/FE/src/components/Modal/index.tsx
@@ -1,0 +1,19 @@
+import ReactDom from 'react-dom';
+
+import * as S from './style';
+
+interface ModalProps {
+  children: React.ReactNode;
+}
+
+export default function Modal({ children }: ModalProps) {
+  return ReactDom.createPortal(
+    <>
+      <S.ModalOverlay />
+      <S.ModalWrapper>
+        <S.ModalContent>{children}</S.ModalContent>
+      </S.ModalWrapper>
+    </>,
+    document.querySelector('#modal-root')!,
+  );
+}

--- a/FE/src/components/Modal/style.ts
+++ b/FE/src/components/Modal/style.ts
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+
+import { flexbox } from '@styles/mixin';
+
+export const ModalCloseBtn = styled.button`
+  border: none;
+  background: transparent;
+  cursor: pointer;
+`;
+
+export const ModalContent = styled.div`
+  position: relative;
+  top: 50%;
+  ${flexbox({ dir: 'column', ai: 'center' })};
+  padding: 2rem 3rem;
+  transform: translateY(-50%);
+  background-color: #fff;
+  box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalWrapper = styled.div`
+  position: fixed;
+  max-width: 30rem;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+  margin: 0 auto;
+`;
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 999;
+  background-color: rgba(0, 0, 0, 0.6);
+`;

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -3,3 +3,23 @@ export const defaultProfileImageUrl =
 
 export const searchDebounceDelay = 300;
 export const limitedLengthSearchValue = 40;
+export const radioColorText = ['어두운색', '밝은색'];
+export const initBgColor = '#EFF0F6';
+export const defaultBgColors = [
+  '#B60205',
+  '#D93F0B',
+  '#FBCA04',
+  '#0E8A16',
+  '#006B75',
+  '#1D76DB',
+  '#0052CC',
+  '#5319E7',
+  '#E99695',
+  '#F9D0C4',
+  '#FEF2C0',
+  '#C2E0C6',
+  '#BFDADC',
+  '#C5DEF5',
+  '#BFD4F2',
+  '#D4C5F9',
+];

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -52,21 +52,21 @@ const getLable = rest.get('/issue/label', (req, res, ctx) =>
     ctx.delay(1000),
     ctx.json([
       {
-        id: 1,
+        id: 81,
         backgroundColor: '#F7F7FC',
         title: 'duplicate',
         description: 'duplicate Des',
         textColor: 'BLACK',
       },
       {
-        id: 2,
+        id: 82,
         backgroundColor: '#004DE3',
         title: 'documentation',
         description: 'documentation Des',
         textColor: 'WHITE',
       },
       {
-        id: 3,
+        id: 83,
         backgroundColor: '#C60B00',
         title: 'bug',
         description: 'bug Des',

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -53,29 +53,50 @@ const getLable = rest.get('/issue/label', (req, res, ctx) =>
     ctx.json([
       {
         id: 1,
-        color: '#F7F7FC',
-        name: 'duplicate',
-        darkText: true,
+        backgroundColor: '#F7F7FC',
+        title: 'duplicate',
+        description: 'duplicate Des',
+        textColor: 'BLACK',
       },
       {
         id: 2,
-        color: '#004DE3',
-        name: 'documentation',
-        darkText: false,
+        backgroundColor: '#004DE3',
+        title: 'documentation',
+        description: 'documentation Des',
+        textColor: 'WHITE',
       },
       {
         id: 3,
-        color: '#C60B00',
-        name: 'bug',
-        darkText: false,
+        backgroundColor: '#C60B00',
+        title: 'bug',
+        description: 'bug Des',
+        textColor: 'WHITE',
       },
     ]),
   ),
 );
 
+const postLabel = rest.post('/issue/label', (req, res, ctx) => {
+  const { title, backgroundColor, description, textColor } = JSON.parse(
+    req.body,
+  );
+
+  return res(
+    ctx.status(200),
+    ctx.delay(1000),
+    ctx.json({
+      title,
+      backgroundColor,
+      description,
+      textColor,
+    }),
+  );
+});
+
 export const handlers = [
   getIssue,
   getLable,
+  postLabel,
   GitHubLogin,
   RefreshGitHubLogin,
   PostIssue,

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -35,7 +35,9 @@ export default function LabelPage() {
           </Button>
         )}
       </S.Header>
-      {openForm && <Form title="새로운 레이블 추가" />}
+      {openForm && (
+        <Form title="새로운 레이블 추가" setOpenForm={setOpenForm} />
+      )}
       <S.Main>
         <S.LabelCount>
           {status === 'success' ? data.length : 0}개의 레이블
@@ -44,8 +46,11 @@ export default function LabelPage() {
           data.map((label: ILabelTypes) => (
             <S.LabelItemWrapper key={label.id}>
               <S.LabelLeft>
-                <Label bgColor={label.color} darkText={label.darkText}>
-                  {label.name}
+                <Label
+                  bgColor={label.backgroundColor}
+                  darkText={label.textColor === 'BLACK'}
+                >
+                  {label.title}
                 </Label>
                 <S.LabelTitle>Label Title</S.LabelTitle>
               </S.LabelLeft>

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 
@@ -7,6 +8,7 @@ import { Button } from '@components/Button';
 import I from '@components/Icons';
 import { Label } from '@components/Label';
 import Form from '@components/Label/Form';
+import Modal from '@components/Modal';
 import TabList from '@components/TabList';
 import { ILabelTypes } from '@recoil/atoms/label';
 
@@ -22,6 +24,9 @@ export default function LabelPage() {
     {},
   );
 
+  const [modalVisible, setModalVisible] = useState(false);
+  const [deleteId, setDeleteId] = useState(0);
+
   const handleLabelEditClick = (id: number) => {
     setEditOpenForm(prevEditFormState => ({
       ...prevEditFormState,
@@ -30,7 +35,18 @@ export default function LabelPage() {
   };
 
   const handleLabelDeleteClick = (id: number) => {
+    setModalVisible(true);
+    setDeleteId(id);
+  };
+
+  const handleLabelDeleteCancel = () => {
+    setModalVisible(false);
+  };
+
+  const handleLabelDeleteSubmit = () => {
     // TODO delete api request
+    console.log(deleteId);
+    setModalVisible(false);
   };
 
   const handleCloseForm = (id?: number) => {
@@ -115,6 +131,32 @@ export default function LabelPage() {
               </S.LabelItemWrapper>
             ),
           )}
+        {modalVisible && (
+          <Modal>
+            <header
+              css={css`
+                margin-bottom: 2rem;
+              `}
+            >
+              해당 레이블을 정말 삭제하시겠습니까?
+            </header>
+            <div>
+              <Button
+                outlined
+                type="button"
+                onClick={handleLabelDeleteCancel}
+                css={css`
+                  margin-right: 1rem;
+                `}
+              >
+                닫기
+              </Button>
+              <Button type="button" onClick={handleLabelDeleteSubmit}>
+                확인
+              </Button>
+            </div>
+          </Modal>
+        )}
       </S.Main>
     </S.LabelPageLayer>
   );

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -18,6 +18,31 @@ const getLabels = async () => {
 export default function LabelPage() {
   const { data, status } = useQuery('labelData', getLabels);
   const [openForm, setOpenForm] = useState(false);
+  const [editOpenForm, setEditOpenForm] = useState<{ [id: number]: boolean }>(
+    {},
+  );
+
+  const handleLabelEditClick = (id: number) => {
+    setEditOpenForm(prevEditFormState => ({
+      ...prevEditFormState,
+      [id]: true,
+    }));
+  };
+
+  const handleLabelDeleteClick = (id: number) => {
+    // TODO delete api request
+  };
+
+  const handleCloseForm = (id?: number) => {
+    if (id) {
+      setEditOpenForm(prevEditFormState => ({
+        ...prevEditFormState,
+        [id]: false,
+      }));
+    } else {
+      setOpenForm(false);
+    }
+  };
 
   return (
     <S.LabelPageLayer>
@@ -36,36 +61,60 @@ export default function LabelPage() {
         )}
       </S.Header>
       {openForm && (
-        <Form title="새로운 레이블 추가" setOpenForm={setOpenForm} />
+        <Form
+          title="새로운 레이블 추가"
+          onEdit={false}
+          handleCloseForm={handleCloseForm}
+        />
       )}
       <S.Main>
         <S.LabelCount>
           {status === 'success' ? data.length : 0}개의 레이블
         </S.LabelCount>
         {status === 'success' &&
-          data.map((label: ILabelTypes) => (
-            <S.LabelItemWrapper key={label.id}>
-              <S.LabelLeft>
-                <Label
-                  bgColor={label.backgroundColor}
-                  darkText={label.textColor === 'BLACK'}
-                >
-                  {label.title}
-                </Label>
-                <S.LabelTitle>Label Title</S.LabelTitle>
-              </S.LabelLeft>
-              <S.LabelRight>
-                <S.EditBox>
-                  <I.Edit />
-                  <span>편집</span>
-                </S.EditBox>
-                <S.TrashBox>
-                  <I.Trash />
-                  <span>삭제</span>
-                </S.TrashBox>
-              </S.LabelRight>
-            </S.LabelItemWrapper>
-          ))}
+          data.map((label: ILabelTypes) =>
+            editOpenForm[label.id] ? (
+              <Form
+                key={`EditLabelForm-${label.title}`}
+                title="레이블 편집"
+                onEdit
+                labelData={label}
+                handleCloseForm={id => handleCloseForm(id)}
+              />
+            ) : (
+              <S.LabelItemWrapper key={label.id}>
+                <S.LabelLeft>
+                  <Label
+                    bgColor={label.backgroundColor}
+                    darkText={label.textColor === 'BLACK'}
+                  >
+                    {label.title}
+                  </Label>
+                  <S.LabelTitle>Label Title</S.LabelTitle>
+                </S.LabelLeft>
+                <S.LabelRight>
+                  <button
+                    type="button"
+                    onClick={() => handleLabelEditClick(label.id)}
+                  >
+                    <S.EditBox>
+                      <I.Edit />
+                      <span>편집</span>
+                    </S.EditBox>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleLabelDeleteClick(label.id)}
+                  >
+                    <S.TrashBox>
+                      <I.Trash />
+                      <span>삭제</span>
+                    </S.TrashBox>
+                  </button>
+                </S.LabelRight>
+              </S.LabelItemWrapper>
+            ),
+          )}
       </S.Main>
     </S.LabelPageLayer>
   );

--- a/FE/src/pages/LabelPage/style.ts
+++ b/FE/src/pages/LabelPage/style.ts
@@ -47,6 +47,9 @@ export const LabelLeft = styled.div`
 export const LabelRight = styled.div`
   ${flexbox};
   gap: 1.7rem;
+  button {
+    background-color: transparent;
+  }
 `;
 
 export const LabelItemWrapper = styled.div`

--- a/FE/src/pages/LabelPage/style.ts
+++ b/FE/src/pages/LabelPage/style.ts
@@ -65,4 +65,6 @@ export const Main = styled.div`
   overflow: hidden;
 `;
 
-export const LabelPageLayer = styled.div``;
+export const LabelPageLayer = styled.div`
+  margin-bottom: 6rem;
+`;

--- a/FE/src/recoil/atoms/label.ts
+++ b/FE/src/recoil/atoms/label.ts
@@ -4,6 +4,7 @@ export interface ILabelTypes {
   id: number;
   backgroundColor: string;
   title: string;
+  description?: string;
   textColor: string;
 }
 

--- a/FE/src/recoil/atoms/label.ts
+++ b/FE/src/recoil/atoms/label.ts
@@ -2,9 +2,9 @@ import { atom } from 'recoil';
 
 export interface ILabelTypes {
   id: number;
-  color: string;
-  name: string;
-  darkText?: boolean;
+  backgroundColor: string;
+  title: string;
+  textColor: string;
 }
 
 export const labelState = atom<{ info: ILabelTypes[] }>({
@@ -13,13 +13,15 @@ export const labelState = atom<{ info: ILabelTypes[] }>({
     info: [
       {
         id: 1,
-        color: '#000000',
-        name: 'colaLabel',
+        backgroundColor: '#000000',
+        title: 'colaLabel',
+        textColor: 'BLACK',
       },
       {
         id: 2,
-        color: '#0025E7',
-        name: 'muffinLabel',
+        backgroundColor: '#0025E7',
+        title: 'muffinLabel',
+        textColor: 'BLACK',
       },
     ],
   },

--- a/FE/src/recoil/atoms/milestone.ts
+++ b/FE/src/recoil/atoms/milestone.ts
@@ -11,11 +11,11 @@ export const mileStoneState = atom<{ info: IMileStoneTypes[] }>({
     info: [
       {
         id: 1,
-        name: 'muffinMileStone',
+        name: 'muffinMileStone한글네글',
       },
       {
         id: 2,
-        name: 'colaMileStone',
+        name: 'colaMileStone한글셋',
       },
     ],
   },


### PR DESCRIPTION
## 🤷‍♂️ Description

![레이블 페이지 데모](https://user-images.githubusercontent.com/45479309/176142287-fdf3ac58-3adf-44ba-85ce-1ad8c3e1d80c.gif)

현재 api를 제외한 기능은 얼추 완성되었습니다.
작업한 내용이 현재는 컴포넌트 하나에 코드가 좀 많이 들어가서 코드 읽기가 불편하실 것 같아서 따로 정리했습니다.

우선 Label 컴포넌트 안의 Form 컴포넌트를 생성했을때와 수정했을때 Form 컴포넌트를 어떻게 각각 보여줄지에 대하여 생각하느라 시간이 많이 들어갔습니다.

### components/Label/Form.tsx 컴포넌트 

Props로는 
title ->  추가폼 수정폼 마다 보여주는 string title, 
labelData -> 수정폼을 열었을땐 그 레이블이 갖고있는 데이터를 보여줘야하므로
onEdit -> 수정폼을 열었는지? 불린형 상태
handleCloseForm -> 추가폼이나 수정폼 둘다 이 handleCLoseForm 인자에 id값의 여부로 폼을 닫도록 하였어요 (id값이 있으면 수정폼이 열려있는 거니까, 없으면 추가폼인거고?)
 
### 다음으로 Form 컴포넌트내 핵심 상태는 아래 2가지입니다.

openFormValue : 레이블 Form안의 데이터들을 객체로 관리하는 상태
initFormValue: 수정폼에서 이전에 수정된 내용을 계속 체킹하기 위해서 초기의 Form값만 들고 있는 상태

### LabelPage/index.tsx 컴포넌트
상태 정리

openForm: 추가폼이 열렸는지 체킹하는 불린형상태
editOpenForm: 각 레이블마다 수정폼이 열려있는지 체킹하는데 객체로 관리했습니다. ({label_id: false}, {label_id: true}) 요런식으로.. (이 부분은 어떻게 할지 좀 고민했었는데 수정폼을 하나씩만 열도록 할까 하다가 다중으로 열어도 괜찮을것 같아서 이렇게 작업했습니다.)
modalVisible: 모달이 열려있는지 체킹하는 불린형 상태 (삭제 버튼 클릭시 보여주는 모달입니다.)
deleteId: 삭제 모달창이 띄워졌을때 어떤 레이블의 id를 삭제할건지 보관하기 위한 상태 (컴포넌트 구조를 바꿔야하나 하다가 다른 방법이 떠오르지 않아서 우선은 상태를 하나 두었습니다..)

현재 create, update, delete 기능을해도 데이터는 변하지 않는 상태입니다.
따라서 각 create,update,delete시에 api를 보내서 (지금은 msw로 테스팅중이지만) react-query 기반의 mutation 녀석을 사용해서 상태를 어떻게 관리할지 고민을 좀 더 해보고 작업할게요!