### PR TITLE
[FE][Muffin] url 값에 따라서 Search Input Value 셋팅

### DIFF
--- a/FE/src/components/Issue/Filter/index.tsx
+++ b/FE/src/components/Issue/Filter/index.tsx
@@ -11,44 +11,45 @@ import { useSearch } from '@hooks/useSearch';
 
 interface IFilterProps {
   onPopup: boolean;
-  label: FilterLabelTypes;
+  item: FilterLabelTypes;
   filterPopupData: IPopupData[];
-  handleFilterClick: (label: FilterLabelTypes, status: boolean) => void;
+  handleFilterClick: (item: FilterLabelTypes, status: boolean) => void;
 }
 
 export default function Filter({
   onPopup,
-  label,
+  item,
   filterPopupData,
   handleFilterClick,
 }: IFilterProps) {
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
   const handleOnFilterPopup = () => {
-    handleFilterClick(label, true);
+    handleFilterClick(item, true);
     setIsComponentVisible(!isComponentVisible);
   };
-  const { replace } = useSearch('q', '');
+  const { replace } = useSearch('q', 'is:open');
 
   const handleItemClick = (
     e: React.MouseEvent<HTMLElement>,
     popupData: IPopupData,
   ) => {
     e.stopPropagation();
-    replace(label, popupData.name);
+    if (item === 'label') replace(item, popupData.title);
+    else replace(item, popupData.name);
     setIsComponentVisible(false);
   };
 
   return (
     <S.FilterLayer onClick={handleOnFilterPopup}>
-      <span className="filter__label">{label}</span>
+      <span className="filter__label">{item}</span>
       <S.ArrowDown />
       {/**
        * // TODO
        * 초기에 여러개의 필터 팝업창 중에 하나의 필터 팝업창만 어떻게 띄울까 고민함
        * 팝업마다 보여줘야할 데이터가 다르기 때문에 팝업의 상태를 객체로 관리하는게 맞을꺼같아 우선 진행
-       * 현재 모든 팝업의 상태를 불린형태로 popupState[label]로 관리
-       * popupState[label]이 true인 팝업만 초기에 띄워주지만
+       * 현재 모든 팝업의 상태를 불린형태로 popupState[item]로 관리
+       * popupState[item]이 true인 팝업만 초기에 띄워주지만
        * 모든 팝업을 한 번씩 클릭하면 결국 전부 true가 되서 초기에만 사용되는 변수값으로 전락되버림
        *
        *
@@ -67,11 +68,11 @@ export default function Filter({
         >
           {isComponentVisible && (
             <Popup>
-              <header>{label} 필터</header>
+              <header>{item} 필터</header>
               {filterPopupData.map((popupData: IPopupData) => (
                 <Contents
                   key={`popup-${popupData.id}`}
-                  label={label}
+                  item={item}
                   popupData={popupData}
                   handleItemClick={handleItemClick}
                 />

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -103,12 +103,12 @@ export default function Navigation() {
         </S.IssueLabel>
       </S.LeftLayer>
       <S.RightLayer>
-        {filterLabels.map((label: FilterLabelTypes) => (
+        {filterLabels.map((item: FilterLabelTypes) => (
           <Filter
-            key={label}
-            onPopup={onPopup(label)}
-            label={label}
-            filterPopupData={filterPopupData[label].info}
+            key={item}
+            onPopup={onPopup(item)}
+            item={item}
+            filterPopupData={filterPopupData[item].info}
             handleFilterClick={handleFilterClick}
           />
         ))}

--- a/FE/src/components/Popup/Contents.tsx
+++ b/FE/src/components/Popup/Contents.tsx
@@ -4,7 +4,7 @@ import { IPopupData } from '@components/Popup/type';
 import theme from '@styles/theme';
 
 interface ContentsProps {
-  label: string;
+  item: string;
   popupData: IPopupData;
   handleItemClick: (
     e: React.MouseEvent<HTMLElement>,
@@ -13,7 +13,7 @@ interface ContentsProps {
 }
 
 export default function Contents({
-  label,
+  item,
   popupData,
   handleItemClick,
 }: ContentsProps) {
@@ -23,7 +23,7 @@ export default function Contents({
       className="filter__item-button"
       onClick={e => handleItemClick(e, popupData)}
     >
-      <div className="filter__item">{getModalItem(label, popupData)}</div>
+      <div className="filter__item">{getModalItem(item, popupData)}</div>
       <div className="filter__check">
         <I.Circle.Check color={theme.color.body} />
       </div>

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -2,8 +2,8 @@ import { css } from '@emotion/react';
 
 import { IPopupData } from '@components/Popup/type';
 
-export const getModalItem = (label: string, popupData: IPopupData) => {
-  switch (label) {
+export const getModalItem = (item: string, popupData: IPopupData) => {
+  switch (item) {
     case '이슈':
       return <div id={popupData.status}>{popupData.name}</div>;
     case 'author':

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -2,7 +2,7 @@ export const defaultProfileImageUrl =
   'https://www.stignatius.co.uk/wp-content/uploads/2020/10/default-user-icon.jpg';
 
 export const searchDebounceDelay = 300;
-export const limitedLengthSearchValue = 40;
+export const limitedLengthSearchValue = 60;
 export const radioColorText = ['어두운색', '밝은색'];
 export const initBgColor = '#EFF0F6';
 export const defaultBgColors = [


### PR DESCRIPTION
## 🤷‍♂️ Description

약간의 네이밍 수정 (label 로 표현되는 값(마일스톤, 레이블, 작성자, 담당자를 일컫는 변수)을 -> item으로 수정)  레이블이라는 값 자체가 안에 있어서.. 뭔가 저도 헷갈려서 수정했습니다.

![init issue main](https://user-images.githubusercontent.com/45479309/176359779-f1272cd5-63d9-43d4-8c9b-58430fe9c374.png)

로그인 이후에 이슈 메인 페이지에 접속했을때 무조건 검색창 인풋에 is:open value가 셋팅되도록 하였습니다.

(url은 안변함. ⇒ [http://localhost:8000/issue](http://localhost:8000/issue))

## 📷 Screenshots

<img width="602" alt="이슈 필터 팝업창" src="https://user-images.githubusercontent.com/45479309/176359806-fa359bf1-93e8-43e1-a6ed-49e33814e29f.png">

이슈 필터 팝업에선 Github Issue 와 동일하게 동작되도록 하였습니다. 

열린 이슈, 닫힌 이슈를 클릭 시 ⇒ init함수로 초기화하므로 url 뿐만아니라 searchInput 값도 is:open 또는 is:close로만 변경됨

내가 작성한 이슈, 나에게 할당된 이슈, 내가 댓글을 남긴 이슈 클릭 시 ⇒ replace(’me’, 각 항목에대한 값) 함수가 동작하므로 뒤에 동일 key값 체킹하면서 붙여줌

## TODO

<img width="619" alt="인풋 열린이슈" src="https://user-images.githubusercontent.com/45479309/176359955-c56266c6-d7a5-4d2a-977d-b029d48bb3dc.png">

위 내용에서  네비게이션 닫힌 이슈를 클릭했을때 초기화 하는게 아닌 다른 값들은 유지하고 open, close만 바뀌도록 아래 처럼 변경되도록 작업이 필요한데 이 부분은 api가 도착하면 해도 될 것 같다고 판단했습니다. 열린 이슈 , 닫힌 이슈 눌러도 초기화해줘도 기능상 문제는 없어보여서요

<img width="610" alt="인풋 닫힌이슈" src="https://user-images.githubusercontent.com/45479309/176359959-15f1d9cf-4cb2-4f06-b23b-7c8a1836bde8.png">

