### PR TITLE
[FE][Muffin] 이슈 메인 페이지 체크박스 기능 구현

### DIFF
--- a/FE/src/components/Issue/Item/index.tsx
+++ b/FE/src/components/Issue/Item/index.tsx
@@ -17,16 +17,30 @@ interface IIssueItem {
   title: string;
 }
 
+interface IssueItemProps {
+  issue: IIssueItem;
+  lastIdx?: boolean;
+  isCheck: boolean;
+  handleIssueCheck: (id: number) => void;
+}
+
 export default function Item({
   issue,
   lastIdx,
-}: {
-  issue: IIssueItem;
-  lastIdx?: boolean;
-}) {
+  isCheck,
+  handleIssueCheck,
+}: IssueItemProps) {
   return (
     <ItemLayer lastIdx={lastIdx}>
-      <I.CheckBox.Initial color="#D9DBE9" />
+      {isCheck ? (
+        <button type="button" onClick={() => handleIssueCheck(issue.id)}>
+          <I.CheckBox.Active color="#007AFF" />
+        </button>
+      ) : (
+        <button type="button" onClick={() => handleIssueCheck(issue.id)}>
+          <I.CheckBox.Initial color="#D9DBE9" />
+        </button>
+      )}
       <ContentLayer>
         <div>
           <I.Circle.Alert color="#007AFF" />

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -39,6 +39,9 @@ export const getModalItem = (item: string, popupData: IPopupData) => {
       );
     case 'mileStone':
       return <div className="filter__name">{popupData.name}</div>;
+
+    case 'checkStatus':
+      return <div className="filter__name">{popupData.name}</div>;
     default:
       throw Error('label type not found');
   }

--- a/FE/src/pages/LabelPage/index.tsx
+++ b/FE/src/pages/LabelPage/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
-import { useQuery } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 import * as S from './style';
 
@@ -18,6 +18,7 @@ const getLabels = async () => {
 };
 
 export default function LabelPage() {
+  const queryClient = useQueryClient();
   const { data, status } = useQuery('labelData', getLabels);
   const [openForm, setOpenForm] = useState(false);
   const [editOpenForm, setEditOpenForm] = useState<{ [id: number]: boolean }>(
@@ -43,9 +44,20 @@ export default function LabelPage() {
     setModalVisible(false);
   };
 
+  const deleteLabel = useMutation(
+    (id: number) =>
+      fetch(`/issue/label/${id}`, {
+        method: 'DELETE',
+      }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('labelData');
+      },
+    },
+  );
+
   const handleLabelDeleteSubmit = () => {
-    // TODO delete api request
-    console.log(deleteId);
+    deleteLabel.mutate(deleteId);
     setModalVisible(false);
   };
 

--- a/FE/src/styles/GlobalStyle.tsx
+++ b/FE/src/styles/GlobalStyle.tsx
@@ -147,6 +147,7 @@ const style = css`
 
   button {
     cursor: pointer;
+    background-color: transparent;
   }
 `;
 


### PR DESCRIPTION
## 🤷‍♂️ Description

handleIssueAllCheck 함수 내 로직을 지금처럼 말고 useState set함수에서 바로 제어 하고 싶었는데 생각보다 잘 안돼서 우선은 새로운 객체를 만들어서 셋팅하는 식으로 했습니다.

체크박스 기능 구현을 위해 
allcheck 상태 -> 모든 체크박스를 관리하는 상태
checkIssue 상태 -> 이슈 각 id마다 관리하는 상태 
2가지를 두었어요.

남아있는 이슈는
이슈 컴포넌트가 로드될때 받아온 이슈 데이터를 가공해  useEffect함수에서 setCheckIssue 셋팅해주는데 현재는 열린 이슈 닫힌 이슈 모두 들어가져서 url에서 값을 빼와서 open & close 구별할지 데이터 파싱 필요한데 어떤식으로 할지 고민중입니다.
