### PR TITLE
[FE][Muffin]: 마일스톤 UI 작업 진행 완료

### DIFF
--- a/FE/src/components/Indicator/Form.tsx
+++ b/FE/src/components/Indicator/Form.tsx
@@ -1,0 +1,3 @@
+export default function Form() {
+  return <div>Milestone Form 구현 예정!</div>;
+}

--- a/FE/src/pages/Milestone/index.tsx
+++ b/FE/src/pages/Milestone/index.tsx
@@ -48,7 +48,7 @@ export default function Milestone() {
             onClick={() => handleLabelClick('open')}
           >
             <I.MileStone />
-            <span>열린 이슈({openMileStoneCount})</span>
+            <span>열린 마일스톤({openMileStoneCount})</span>
           </S.MileStoneLabel>
 
           <S.MileStoneLabel
@@ -56,7 +56,7 @@ export default function Milestone() {
             onClick={() => handleLabelClick('close')}
           >
             <I.Bucket />
-            <span>닫힌 이슈({closeMileStoneCount})</span>
+            <span>닫힌 마일스톤({closeMileStoneCount})</span>
           </S.MileStoneLabel>
         </S.MainHeaderLabel>
 

--- a/FE/src/pages/Milestone/index.tsx
+++ b/FE/src/pages/Milestone/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 
@@ -9,7 +8,6 @@ import I from '@components/Icons';
 import { ProgressBar } from '@components/Indicator';
 import Form from '@components/Indicator/Form';
 import TabList from '@components/TabList';
-import { typoMedium, typoSmall, flexbox } from '@styles/mixin';
 
 export default function Milestone() {
   const [openForm, setOpenForm] = useState(false);
@@ -64,88 +62,36 @@ export default function Milestone() {
 
         <S.MileStoneItemWrapper>
           <S.MileStoneLeft>
-            <S.MileStoneTitle
-              css={css`
-                margin-bottom: 1rem;
-              `}
-            >
+            <S.MileStoneTitle>
               <div>
                 <I.MileStone color="#007AFF" />
-                <span
-                  css={css`
-                    margin-left: 0.5rem;
-                    ${typoMedium(700)}
-                  `}
-                >
-                  마일스톤 제목
-                </span>
+                <span className="milestone-mainTitle">마일스톤 제목</span>
               </div>
               <div>
                 <I.Calendar color="#6E7191" />
-                <span
-                  css={css`
-                    margin-left: 0.5rem;
-                    color: #6e7191;
-                    ${typoSmall(400)}
-                  `}
-                >
-                  2022-06-30
-                </span>
+                <span className="milestone-date">2022-06-30</span>
               </div>
             </S.MileStoneTitle>
-            <p
-              css={css`
-                color: #6e7191;
-                ${typoSmall(400)};
-              `}
-            >
-              레이블에 대한 설명
-            </p>
+            <p className="milestone-des">레이블에 대한 설명</p>
           </S.MileStoneLeft>
           <S.MileStoneRight>
-            <div
-              css={css`
-                gap: 2rem;
-                ${flexbox({})}
-              `}
-            >
+            <div className="milestone-buttons">
               <div>
                 <button type="button">
                   <I.Bucket color="#6E7191" />
-                  <span
-                    css={css`
-                      margin-left: 0.5rem;
-                      color: #6e7191;
-                    `}
-                  >
-                    닫기
-                  </span>
+                  <span className="button--text">닫기</span>
                 </button>
               </div>
               <div>
                 <button type="button">
                   <I.Edit color="#6E7191" />
-                  <span
-                    css={css`
-                      margin-left: 0.5rem;
-                      color: #6e7191;
-                    `}
-                  >
-                    편집
-                  </span>
+                  <span className="button--text">편집</span>
                 </button>
               </div>
               <div>
                 <button type="button">
                   <I.Trash color="#FF3B30" />
-                  <span
-                    css={css`
-                      margin-left: 0.5rem;
-                      color: #ff3b30;
-                    `}
-                  >
-                    삭제
-                  </span>
+                  <span className="button--delete">삭제</span>
                 </button>
               </div>
             </div>

--- a/FE/src/pages/Milestone/index.tsx
+++ b/FE/src/pages/Milestone/index.tsx
@@ -1,9 +1,163 @@
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+
+import * as S from './style';
+
+import { Button } from '@components/Button';
+import I from '@components/Icons';
+import { ProgressBar } from '@components/Indicator';
+import Form from '@components/Indicator/Form';
 import TabList from '@components/TabList';
+import { typoMedium, typoSmall, flexbox } from '@styles/mixin';
 
 export default function Milestone() {
+  const [openForm, setOpenForm] = useState(false);
+  const [labelMileStoneStatus, setLabelMileStoneStatus] = useState(true);
+
+  const handleLabelClick = (status: string) => {
+    if (status === 'open') {
+      setLabelMileStoneStatus(true);
+    } else if (status === 'close') {
+      setLabelMileStoneStatus(false);
+    }
+  };
+
+  const openMileStoneCount = 1;
+  const closeMileStoneCount = 3;
+
   return (
-    <div>
-      <TabList />
-    </div>
+    <S.LabelPageLayer>
+      <S.Header>
+        <TabList />
+        {openForm ? (
+          <Button onClick={() => setOpenForm(!openForm)} outlined>
+            <I.XMark color="#007AFF" />
+            닫기
+          </Button>
+        ) : (
+          <Button onClick={() => setOpenForm(!openForm)}>
+            <I.Plus />
+            추가
+          </Button>
+        )}
+      </S.Header>
+      {openForm && <Form />}
+      <S.Main>
+        <S.MainHeaderLabel>
+          <S.MileStoneLabel
+            labelMileStoneStatus={labelMileStoneStatus}
+            onClick={() => handleLabelClick('open')}
+          >
+            <I.MileStone />
+            <span>열린 이슈({openMileStoneCount})</span>
+          </S.MileStoneLabel>
+
+          <S.MileStoneLabel
+            labelMileStoneStatus={!labelMileStoneStatus}
+            onClick={() => handleLabelClick('close')}
+          >
+            <I.Bucket />
+            <span>닫힌 이슈({closeMileStoneCount})</span>
+          </S.MileStoneLabel>
+        </S.MainHeaderLabel>
+
+        <S.MileStoneItemWrapper>
+          <S.MileStoneLeft>
+            <S.MileStoneTitle
+              css={css`
+                margin-bottom: 1rem;
+              `}
+            >
+              <div>
+                <I.MileStone color="#007AFF" />
+                <span
+                  css={css`
+                    margin-left: 0.5rem;
+                    ${typoMedium(700)}
+                  `}
+                >
+                  마일스톤 제목
+                </span>
+              </div>
+              <div>
+                <I.Calendar color="#6E7191" />
+                <span
+                  css={css`
+                    margin-left: 0.5rem;
+                    color: #6e7191;
+                    ${typoSmall(400)}
+                  `}
+                >
+                  2022-06-30
+                </span>
+              </div>
+            </S.MileStoneTitle>
+            <p
+              css={css`
+                color: #6e7191;
+                ${typoSmall(400)};
+              `}
+            >
+              레이블에 대한 설명
+            </p>
+          </S.MileStoneLeft>
+          <S.MileStoneRight>
+            <div
+              css={css`
+                gap: 2rem;
+                ${flexbox({})}
+              `}
+            >
+              <div>
+                <button type="button">
+                  <I.Bucket color="#6E7191" />
+                  <span
+                    css={css`
+                      margin-left: 0.5rem;
+                      color: #6e7191;
+                    `}
+                  >
+                    닫기
+                  </span>
+                </button>
+              </div>
+              <div>
+                <button type="button">
+                  <I.Edit color="#6E7191" />
+                  <span
+                    css={css`
+                      margin-left: 0.5rem;
+                      color: #6e7191;
+                    `}
+                  >
+                    편집
+                  </span>
+                </button>
+              </div>
+              <div>
+                <button type="button">
+                  <I.Trash color="#FF3B30" />
+                  <span
+                    css={css`
+                      margin-left: 0.5rem;
+                      color: #ff3b30;
+                    `}
+                  >
+                    삭제
+                  </span>
+                </button>
+              </div>
+            </div>
+            <ProgressBar
+              width={50}
+              detail
+              leftText={`열린 이슈 ${0}`}
+              rightText={`닫힌 이슈 ${0}`}
+            />
+          </S.MileStoneRight>
+        </S.MileStoneItemWrapper>
+      </S.Main>
+    </S.LabelPageLayer>
   );
 }

--- a/FE/src/pages/Milestone/style.ts
+++ b/FE/src/pages/Milestone/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { typoSmall, flexbox } from '@styles/mixin';
+import { typoSmall, typoMedium, flexbox } from '@styles/mixin';
 import theme from '@styles/theme';
 
 export const Header = styled.header`
@@ -27,8 +27,23 @@ export const MainHeaderLabel = styled.header`
 `;
 
 export const MileStoneTitle = styled.div`
+  margin-bottom: 1rem;
   gap: 0.5rem;
   ${flexbox({ ai: 'center' })};
+
+  .milestone-mainTitle {
+    margin-left: 0.5rem;
+    ${typoMedium(700)}
+  }
+  .milestone-date {
+    margin-left: 0.5rem;
+    color: #6e7191;
+    ${typoSmall(400)}
+  }
+  .milestone-des {
+    color: #6e7191;
+    ${typoSmall(400)};
+  }
 `;
 
 export const MileStoneLeft = styled.div`
@@ -41,6 +56,19 @@ export const MileStoneRight = styled.div`
   gap: 0.5rem;
   button {
     background-color: transparent;
+  }
+  .milestone-buttons {
+    gap: 2rem;
+    ${flexbox({})}
+  }
+  .button--text {
+    margin-left: 0.5rem;
+    color: #6e7191;
+  }
+
+  .button--delete {
+    margin-left: 0.5rem;
+    color: #ff3b30;
   }
 `;
 

--- a/FE/src/pages/Milestone/style.ts
+++ b/FE/src/pages/Milestone/style.ts
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+
+import { typoSmall, flexbox } from '@styles/mixin';
+import theme from '@styles/theme';
+
+export const Header = styled.header`
+  margin-bottom: 1.5rem;
+  ${flexbox({ jc: 'space-between' })};
+`;
+
+export const MileStoneLabel = styled.div`
+  cursor: pointer;
+  color: ${(props: { labelMileStoneStatus: boolean }) =>
+    props.labelMileStoneStatus ? theme.color.titleActive : theme.color.label};
+  span {
+    margin-left: 0.375rem;
+  }
+`;
+
+export const MainHeaderLabel = styled.header`
+  height: 4rem;
+  padding: 1rem 2rem;
+  color: ${theme.color.label};
+  gap: 1rem;
+  ${flexbox({ ai: 'center' })};
+  ${typoSmall(700)}
+`;
+
+export const MileStoneTitle = styled.div`
+  gap: 0.5rem;
+  ${flexbox({ ai: 'center' })};
+`;
+
+export const MileStoneLeft = styled.div`
+  ${flexbox({ dir: 'column', jc: 'center' })};
+  width: 50%;
+`;
+
+export const MileStoneRight = styled.div`
+  ${flexbox({ dir: 'column', ai: 'flex-end' })};
+  gap: 0.5rem;
+  button {
+    background-color: transparent;
+  }
+`;
+
+export const MileStoneItemWrapper = styled.div`
+  padding: 2rem;
+  background-color: ${theme.color.offWhite};
+  border-top: 1px solid;
+  border-color: ${theme.color.line};
+  ${flexbox({ jc: 'space-between' })};
+`;
+
+export const Main = styled.div`
+  min-height: 4rem;
+  border: 1px solid;
+  border-color: ${theme.color.line};
+  border-radius: 1rem;
+  overflow: hidden;
+`;
+
+export const LabelPageLayer = styled.div`
+  margin-bottom: 6rem;
+`;


### PR DESCRIPTION
## 🤷‍♂️ Description

close #115 

<img width="1298" alt="milestone ui" src="https://user-images.githubusercontent.com/45479309/176618567-31460afc-7af6-41b4-b569-b571c43786c3.png">



마일스톤 페이지 접근시 임의로 데이터 뿌려주는거 까지 완료했습니다. 이전에 미리 만들어주신 ProgressBar props에 대한 설명이 노션에 잘 적혀있어서 금방 어떤 props를 넘기면 되겠다라고 느껴서 좋았네요ㅎㅎ..

서버에서 데이터 요청해서 실제 데이터를 마일스톤 페이지에 뿌려주는 작업 진행 이후에 CREATE, DELETE 작업 진행할게요!
UPDATE 기능은 시간상 데모 관련 준비도 좀 해야할 것 같아서 미뤄놀게요
