### PR TITLE
[FE][Cola] 파일 업로드, 드래그앤 드롭

### DIFF
--- a/FE/config/webpack.common.js
+++ b/FE/config/webpack.common.js
@@ -8,7 +8,7 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 dotenv.config({ path: path.join(__dirname, '../env', '.env') });
-const WebpackEnvironmentPlugin = new webpack.EnvironmentPlugin(['TEAM30_BASE_URL', 'TEAM30_GITHUB_OAUTH_URL']);
+const WebpackEnvironmentPlugin = new webpack.EnvironmentPlugin(['TEAM30_BASE_URL', 'TEAM30_GITHUB_OAUTH_URL', 'TEAM30_FILE_UPLOAD_URL']);
 
 module.exports = {
   context: __dirname,

--- a/FE/src/apis/image.ts
+++ b/FE/src/apis/image.ts
@@ -1,0 +1,25 @@
+import { ACCESS_TOKEN } from '@constants/cookie';
+import { getCookie } from '@utils/cookie';
+
+interface PostImageResponse {
+  filename: string;
+  imageUrl: string;
+}
+
+// Content-Type 은 FormData 가 알아서 바꾸기 때문에 적지 않음.
+export const postImage = async (
+  formData: FormData,
+): Promise<PostImageResponse[]> => {
+  const response = await fetch(`${process.env.TEAM30_FILE_UPLOAD_URL}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${getCookie(ACCESS_TOKEN)}`,
+    },
+    body: formData,
+  });
+  const imageInfoArr = await response.json();
+
+  // TODO: 에러핸들링
+
+  return imageInfoArr;
+};

--- a/FE/src/components/Input/index.tsx
+++ b/FE/src/components/Input/index.tsx
@@ -74,7 +74,7 @@ export const TTextarea = <T extends React.ElementType = 'input'>({
   const handleUploadFiles = async (files: FileList | null) => {
     const imageInfoArr = await uploadFiles(files);
 
-    if (!imageInfoArr || !textareaRef.current) {
+    if (!imageInfoArr || !imageInfoArr.length || !textareaRef.current) {
       return;
     }
 

--- a/FE/src/components/Input/style.ts
+++ b/FE/src/components/Input/style.ts
@@ -82,6 +82,7 @@ export const InputLayer = styled.div<{
   error?: boolean;
   success?: boolean;
   active?: boolean;
+  dragEnter?: boolean;
 }>`
   ${typoSmall(400)};
   position: relative;
@@ -166,6 +167,17 @@ export const InputLayer = styled.div<{
       
       ${PlaceHolder} {
         color: ${theme.color.darkRed};
+      };
+  `};
+
+  ${({ dragEnter, theme }) =>
+    dragEnter &&
+    `
+      border-color: ${theme.color.blue} !important;
+      background-color: ${theme.color.lightBlue} !important;
+      
+      ${PlaceHolder} {
+        color: ${theme.color.darkBlue};
       };
   `};
 `;

--- a/FE/src/components/Input/style.ts
+++ b/FE/src/components/Input/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { typoSmall, inlineFlexbox, typoXSmall } from '@styles/mixin';
+import { typoSmall, inlineFlexbox, typoXSmall, flexbox } from '@styles/mixin';
 
 export const WordCount = styled.div`
   ${typoXSmall(400)};
@@ -21,6 +21,7 @@ export const Label = styled.label`
 `;
 
 export const Footer = styled.footer`
+  ${flexbox({ ai: 'center' })};
   height: 3.25rem;
   background-image: linear-gradient(
     to right,
@@ -32,6 +33,17 @@ export const Footer = styled.footer`
   background-repeat: repeat-x;
   padding: 1rem 1.5rem;
   transition: all 100ms;
+`;
+
+export const FileUploadLoader = styled.div`
+  ${flexbox({ ai: 'center' })};
+  padding: 0 0.5rem;
+`;
+
+export const UploadMessage = styled.span`
+  ${typoXSmall(700)};
+  color: ${({ theme }) => theme.color.label};
+  padding: 0 1rem;
 `;
 
 export const PlaceHolder = styled.div`

--- a/FE/src/hooks/useFileUpload.tsx
+++ b/FE/src/hooks/useFileUpload.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useMutation } from 'react-query';
+
+import { postImage } from '@apis/image';
+
+const FORM_DATA_KEY = 'files';
+
+export const useFileUpload = (
+  allowedFileTypes: string[],
+  allowedFileSize = 400 * 1024,
+) => {
+  const { isLoading, mutateAsync } = useMutation(
+    ['fileUpload'],
+    (formData: FormData) => postImage(formData),
+  );
+
+  const uploadFromInput = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { target } = e;
+    if (!target.files) {
+      return undefined;
+    }
+
+    const filteredFiles = filterByTypeAndSize(
+      target.files,
+      allowedFileTypes,
+      allowedFileSize,
+    );
+
+    target.value = '';
+
+    // 업로드
+    const formData = toFormData(filteredFiles);
+    const imageInfoArr = await mutateAsync(formData);
+    return imageInfoArr;
+  };
+
+  // 로딩 상태와 uploadFromInput 반환
+  return { isLoading, uploadFromInput };
+};
+
+const filterByTypeAndSize = (
+  fileList: FileList,
+  fileTypes: string[],
+  fileSize: number,
+) => {
+  const files: File[] = [];
+
+  Array.prototype.forEach.call(fileList, (file: File) => {
+    if (fileTypes.includes(file.type) && file.size <= fileSize) {
+      files.push(file);
+    }
+  });
+
+  return files;
+};
+
+const toFormData = (files: File[]) => {
+  const formData = new FormData();
+  files.forEach(file => {
+    formData.append(FORM_DATA_KEY, file);
+  });
+  return formData;
+};

--- a/FE/src/hooks/useFileUpload.tsx
+++ b/FE/src/hooks/useFileUpload.tsx
@@ -14,19 +14,16 @@ export const useFileUpload = (
     (formData: FormData) => postImage(formData),
   );
 
-  const uploadFromInput = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { target } = e;
-    if (!target.files) {
+  const uploadFiles = async (files: FileList | null) => {
+    if (!files) {
       return undefined;
     }
 
     const filteredFiles = filterByTypeAndSize(
-      target.files,
+      files,
       allowedFileTypes,
       allowedFileSize,
     );
-
-    target.value = '';
 
     // 업로드
     const formData = toFormData(filteredFiles);
@@ -34,8 +31,8 @@ export const useFileUpload = (
     return imageInfoArr;
   };
 
-  // 로딩 상태와 uploadFromInput 반환
-  return { isLoading, uploadFromInput };
+  // 로딩 상태와 uploadFiles 반환
+  return { isLoading, uploadFiles };
 };
 
 const filterByTypeAndSize = (

--- a/FE/src/hooks/useInput.tsx
+++ b/FE/src/hooks/useInput.tsx
@@ -6,5 +6,5 @@ export const useInput = () => {
     setValue(e.target.value);
   };
 
-  return { value, onChange };
+  return { value, onChange, setValue };
 };

--- a/FE/src/mocks/handlers/PostImage.js
+++ b/FE/src/mocks/handlers/PostImage.js
@@ -1,0 +1,20 @@
+import { rest } from 'msw';
+
+export const PostImage = rest.post(
+  `${process.env.TEAM30_FILE_UPLOAD_URL}`,
+  (req, res, ctx) => {
+    console.log(req.body.files);
+    const reqBody =
+      req.body.files.length > 1 ? req.body.files : [req.body.files];
+    return res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json(
+        reqBody.map(({ name }) => ({
+          filename: name,
+          imageUrl: 'url',
+        })),
+      ),
+    );
+  },
+);

--- a/FE/src/mocks/handlers/PostImage.js
+++ b/FE/src/mocks/handlers/PostImage.js
@@ -3,9 +3,16 @@ import { rest } from 'msw';
 export const PostImage = rest.post(
   `${process.env.TEAM30_FILE_UPLOAD_URL}`,
   (req, res, ctx) => {
-    console.log(req.body.files);
-    const reqBody =
-      req.body.files.length > 1 ? req.body.files : [req.body.files];
+    const { files } = req.body;
+
+    let reqBody;
+
+    if (files) {
+      reqBody = files.length > 1 ? files : [files];
+    } else {
+      reqBody = [];
+    }
+
     return res(
       ctx.status(200),
       ctx.delay(1000),

--- a/FE/src/mocks/handlers/index.js
+++ b/FE/src/mocks/handlers/index.js
@@ -5,6 +5,7 @@ import { GetLabels } from './GetLabels';
 import { GetMileStones } from './GetMileStones';
 import { GetUsers } from './GetUsers';
 import { GitHubLogin, RefreshGitHubLogin } from './GitHubLogin';
+import { PostImage } from './PostImage';
 import { PostIssue } from './PostIssue';
 
 const getIssue = rest.get('/issue', (req, res, ctx) =>
@@ -106,4 +107,5 @@ export const handlers = [
   PostIssue,
   GetUsers,
   GetMileStones,
+  PostImage,
 ];


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->
- close #117 
- 파일 업로드


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 버튼으로 파일 업로드하기
- [x] 드래그앤 드롭으로 파일 업로드하기
- [x] 파일 여러개 업로드하기
- [x] 크기 제한하기
- [x] 업로드한 파일을 `![name](url)`형태로 변환하여 `Textarea`의 커서위치에 삽입하기
- [x] Mock API 추가 (PostImage)
- [x] `useFileUpload` 커스텀훅 추가
첫번째 인자로 허용할 파일 타입을 배열로 받고, 두번째 인자로 허용할 파일 크기를 바이트 단위로 받습니다. (기본값은 `400 * 1024`로, 400KB입니다.)

## 📷 Screenshots

업로드 크기 제한은 일단 디폴트값인 400KB로 한 상태입니다.
업로드 파일 타입이나 크기 제한에 걸리게 되면 `filter`로 거르기 때문에 업로드가 되지 않습니다. 

아래 예시에서 `큰파일.gif`은 약 600KB라서 업로드가 되지 않습니다. 

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
![upload](https://user-images.githubusercontent.com/79135734/176669246-2e23f0c3-c92b-4acc-9220-db43eb80eb5d.gif)

![draganddrop](https://user-images.githubusercontent.com/79135734/176669272-8a7b035e-05c6-4e48-b245-e8bca5620303.gif)


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
