### PR TITLE
[FE][Muffin] 팝업 필터 기능 리팩토링

### DIFF
--- a/FE/src/components/Issue/Filter/index.tsx
+++ b/FE/src/components/Issue/Filter/index.tsx
@@ -1,13 +1,15 @@
 import { css } from '@emotion/react';
+import { useSetRecoilState } from 'recoil';
 
 import * as S from './style';
 
-import { FilterLabelTypes } from '@components/Issue/Navigation';
 import Popup from '@components/Popup';
 import Contents from '@components/Popup/Contents';
 import { IPopupData } from '@components/Popup/type';
 import useComponentVisible from '@hooks/useComponentVisible';
 import { useSearch } from '@hooks/useSearch';
+import { issueState } from '@recoil/atoms/issue';
+import { FilterLabelTypes } from '@type/issue';
 
 interface IFilterProps {
   onPopup: boolean;
@@ -24,11 +26,14 @@ export default function Filter({
 }: IFilterProps) {
   const { ref, isComponentVisible, setIsComponentVisible } =
     useComponentVisible(false);
+
   const handleOnFilterPopup = () => {
     handleFilterClick(item, true);
-    setIsComponentVisible(!isComponentVisible);
+    setIsComponentVisible(true);
   };
-  const { urlParamReplace } = useSearch('q', 'is:open');
+  const { urlParamAdd, urlParamReplace } = useSearch('q', 'is:open');
+
+  const setIssueState = useSetRecoilState(issueState);
 
   const handleItemClick = (
     e: React.MouseEvent<HTMLElement>,
@@ -36,8 +41,18 @@ export default function Filter({
   ) => {
     e.stopPropagation();
     if ((e.target as Element).classList.contains('popup-header')) return;
-    if (item === 'label') urlParamReplace(item, popupData.title);
-    else urlParamReplace(item, popupData.name);
+
+    // TODO: 팝업이 더 많아지면 이 if 문들도 많아질텐데...
+    if (item === 'label') {
+      urlParamAdd(item, popupData.title);
+    } else if (item === 'mileStone') {
+      urlParamReplace(item, popupData.title);
+    } else if (item === 'assignee' || item === 'author') {
+      urlParamReplace(item, popupData.name);
+    }
+
+    // TODO: call filter get api => response issue recoil set
+    setIssueState([]);
     setIsComponentVisible(false);
   };
 
@@ -45,17 +60,6 @@ export default function Filter({
     <S.FilterLayer onClick={handleOnFilterPopup}>
       <span className="filter__label">{item}</span>
       <S.ArrowDown />
-      {/**
-       * // TODO
-       * 초기에 여러개의 필터 팝업창 중에 하나의 필터 팝업창만 어떻게 띄울까 고민함
-       * 팝업마다 보여줘야할 데이터가 다르기 때문에 팝업의 상태를 객체로 관리하는게 맞을꺼같아 우선 진행
-       * 현재 모든 팝업의 상태를 불린형태로 popupState[item]로 관리
-       * popupState[item]이 true인 팝업만 초기에 띄워주지만
-       * 모든 팝업을 한 번씩 클릭하면 결국 전부 true가 되서 초기에만 사용되는 변수값으로 전락되버림
-       *
-       *
-       * 각 팝업을감싸는 태그가 ref로 관리되고 있어 isComponentVisible인 true인거만 팝업이 나오는 형태
-       *  */}
 
       {onPopup && (
         <div
@@ -69,7 +73,7 @@ export default function Filter({
         >
           {isComponentVisible && (
             <Popup>
-              <header className="popup-header">{item} 필터</header>
+              <header className="popup-header">{item} Filter</header>
               {filterPopupData.map((popupData: IPopupData) => (
                 <Contents
                   key={`popup-${popupData.id}`}

--- a/FE/src/components/Issue/Navigation/index.tsx
+++ b/FE/src/components/Issue/Navigation/index.tsx
@@ -12,13 +12,7 @@ import { authorState } from '@recoil/atoms/author';
 import { issueState } from '@recoil/atoms/issue';
 import { labelState } from '@recoil/atoms/label';
 import { mileStoneState } from '@recoil/atoms/milestone';
-
-export type FilterLabelTypes =
-  | 'assignee'
-  | 'label'
-  | 'mileStone'
-  | 'author'
-  | 'checkStatus';
+import { FilterLabelTypes } from '@type/issue';
 
 interface NavigationProps {
   allCheck: boolean;
@@ -31,7 +25,6 @@ export default function Navigation({
   calculateCheckCount,
   handleIssueAllCheck,
 }: NavigationProps) {
-  // console.log(calculateCheckCount);
   const { urlParamInit } = useSearch('q', 'is:open');
   const location = useLocation();
   const filterLabels: FilterLabelTypes[] = [
@@ -45,10 +38,10 @@ export default function Navigation({
   const labelData = useRecoilValue(labelState);
   const milestoneData = useRecoilValue(mileStoneState);
   const authorData = useRecoilValue(authorState);
-  const checkStatusData = {
+  const checkBoxStatus = {
     info: [
-      { id: 'open-statusPopup', name: '선택한 이슈 열기' },
-      { id: 'close-statusPopup', name: '선택한 이슈 닫기' },
+      { id: 'open-statusPopup', title: '선택한 이슈 열기' },
+      { id: 'close-statusPopup', title: '선택한 이슈 닫기' },
     ],
   };
 
@@ -59,7 +52,7 @@ export default function Navigation({
     label: false,
     mileStone: false,
     author: false,
-    checkStatus: false,
+    checkBoxStatus: false,
   });
 
   const [filterPopupData, setFilterPoupData] = useState({
@@ -67,7 +60,7 @@ export default function Navigation({
     label: labelData,
     mileStone: milestoneData,
     author: authorData,
-    checkStatus: checkStatusData,
+    checkBoxStatus,
   });
 
   const [labelIssueStatus, setLabelIssueStatus] = useState(true);
@@ -143,9 +136,9 @@ export default function Navigation({
       <S.RightLayer>
         {calculateCheckCount() !== 0 ? (
           <Filter
-            onPopup={onPopup('checkStatus')}
-            item="checkStatus"
-            filterPopupData={filterPopupData.checkStatus.info}
+            onPopup={onPopup('checkBoxStatus')}
+            item="checkBoxStatus"
+            filterPopupData={filterPopupData.checkBoxStatus.info}
             handleFilterClick={handleFilterClick}
           />
         ) : (

--- a/FE/src/components/Issue/index.tsx
+++ b/FE/src/components/Issue/index.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from 'react-query';
-import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 import { IssueWrapperLayer } from './style';
@@ -9,22 +8,15 @@ import Item from '@components/Issue/Item';
 import Navigation from '@components/Issue/Navigation';
 import { IIssueTypes, issueState } from '@recoil/atoms/issue';
 
-interface IKeyParams {
-  [key: string]: string;
-}
-
 interface ICheckIssue {
   id: number;
   check: boolean;
 }
 
 export default function Issue() {
-  // TODO initIssue 와 renderIssue는 현재 필터된 결과를 화면에 뿌려보기 위해 사용한 상태며 차후엔 하나의 상태로 관리
-  const [initIssue, setInitIssue] = useRecoilState(issueState);
-  const [renderIssue, setRenderIssue] = useState<IIssueTypes[]>([]);
+  const [issueList, setIssueList] = useRecoilState(issueState);
   const [allCheck, setAllCheck] = useState(false);
   const [checkIssue, setCheckIssue] = useState<ICheckIssue[]>([]);
-  const location = useLocation();
 
   const handleIssueCheck = (id: number) => {
     setCheckIssue(
@@ -71,63 +63,12 @@ export default function Issue() {
 
   useQuery('issueData', async () => {
     const response = await (await fetch('issue')).json();
-    setInitIssue(response);
-    setRenderIssue(
-      response.filter((issue: IIssueTypes) => issue.status === 'open'),
-    );
+    setIssueList(response);
   });
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const urlValues = params.get('q');
-
-    if (urlValues === null) return;
-
-    const parsingUrlValue = urlValues?.split(' ').map(v => v);
-
-    // 스페이스바 기준으로 나눠진 데이터들 중 다시 sep(:) split =>  Key, value를 담는 배열로 나누는 함수 제작
-    // 뽑은 key, value를 넘겨 기존 issueData를 필터하는 함수 제작
-    const filterDataArray = parsingUrlValue?.map(data => {
-      const obj: IKeyParams = {};
-      const [key, value] = data.split(':');
-      obj[key] = value;
-      return obj;
-    });
-
-    // 백엔드 API가 완성되면 이부분 함수 분리 + 로직 재작성
-    filterDataArray?.forEach(arr => {
-      const key = Object.keys(arr)[0];
-      const value = Object.values(arr)[0];
-
-      switch (key) {
-        case 'is':
-          setRenderIssue(
-            initIssue.filter((issue: IIssueTypes) => issue.status === value),
-          );
-          break;
-        case 'mine':
-          break;
-        case 'assignedToMe':
-          break;
-        case 'comment':
-          break;
-        case 'assignee':
-          break;
-        case 'label':
-          break;
-        case 'mileStone':
-          break;
-        case 'author':
-          break;
-        default:
-          console.log(urlValues);
-      }
-    });
-  }, [initIssue, location]);
-
-  useEffect(() => {
     // open & close 구별해서 데이터 파싱 필요..
-    const initIssueCheck = initIssue.map(issue => {
+    const initIssueCheck = issueList.map(issue => {
       const obj = {} as ICheckIssue;
       obj.id = issue.id;
       obj.check = false;
@@ -135,7 +76,7 @@ export default function Issue() {
     });
 
     setCheckIssue(initIssueCheck);
-  }, [initIssue]);
+  }, [issueList]);
 
   return (
     <IssueWrapperLayer>
@@ -144,11 +85,11 @@ export default function Issue() {
         calculateCheckCount={calculateCheckCount}
         handleIssueAllCheck={handleIssueAllCheck}
       />
-      {renderIssue &&
-        renderIssue.map((issueData: IIssueTypes, index: number) => (
+      {issueList &&
+        issueList.map((issueData: IIssueTypes, index: number) => (
           <Item
             issue={issueData}
-            lastIdx={renderIssue.length === index + 1}
+            lastIdx={issueList.length === index + 1}
             key={`issue-${issueData.id}`}
             isCheck={isCheckIssue(issueData.id)}
             handleIssueCheck={handleIssueCheck}

--- a/FE/src/components/Popup/Item.tsx
+++ b/FE/src/components/Popup/Item.tsx
@@ -38,10 +38,10 @@ export const getModalItem = (item: string, popupData: IPopupData) => {
         </>
       );
     case 'mileStone':
-      return <div className="filter__name">{popupData.name}</div>;
+      return <div className="filter__name">{popupData.title}</div>;
 
-    case 'checkStatus':
-      return <div className="filter__name">{popupData.name}</div>;
+    case 'checkBoxStatus':
+      return <div className="filter__name">{popupData.title}</div>;
     default:
       throw Error('label type not found');
   }

--- a/FE/src/components/Popup/type.ts
+++ b/FE/src/components/Popup/type.ts
@@ -4,7 +4,7 @@
  *  */
 
 export interface IPopupData {
-  id?: number;
+  id?: number | string;
   imageUrl?: string;
   status?: string;
   backgroundColor?: string;

--- a/FE/src/constants/default.ts
+++ b/FE/src/constants/default.ts
@@ -23,3 +23,12 @@ export const defaultBgColors = [
   '#BFD4F2',
   '#D4C5F9',
 ];
+
+export const issueFilterKeys = [
+  'is',
+  'me',
+  'assignee',
+  'label',
+  'mileStone',
+  'author',
+];

--- a/FE/src/hooks/useComponentVisible.tsx
+++ b/FE/src/hooks/useComponentVisible.tsx
@@ -8,10 +8,8 @@ export default function useComponentVisible(initialIsVisible: boolean) {
   const handleClickOutside = (
     e: React.BaseSyntheticEvent | MouseEvent,
   ): void => {
-    if (ref.current) {
-      if (!ref.current.contains(e.target)) {
-        setIsComponentVisible(false);
-      }
+    if (ref.current && !ref.current.contains(e.target)) {
+      setIsComponentVisible(false);
     }
   };
 

--- a/FE/src/type/issue.ts
+++ b/FE/src/type/issue.ts
@@ -1,0 +1,6 @@
+export type FilterLabelTypes =
+  | 'assignee'
+  | 'label'
+  | 'mileStone'
+  | 'author'
+  | 'checkBoxStatus';

--- a/FE/src/utils/inputSearch.ts
+++ b/FE/src/utils/inputSearch.ts
@@ -1,0 +1,12 @@
+import { issueFilterKeys } from '@constants/default';
+
+export const checkSearchParamKey = (searchValue: string) => {
+  const parsingValue = searchValue.split(' ');
+
+  for (let i = 0; i < parsingValue.length; i += 1) {
+    const key = parsingValue[i].split(':')[0];
+    if (!issueFilterKeys.includes(key)) return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## 🤷‍♂️ Description

팝업쪽 로직을 다시 보니까 네이밍이 이상한 부분이 중간중간 보이는 부분 수정하였으며 불필요한 코드도 삭제했습니다.
필터된 데이터를 가져오는 방법으로는 서버에 url을 통째로 넘겨서 필터된 데이터를 받아와서 응답받은 데이터를 뿌려주기만 하면 되니, 

1. 네비게이션 내 필터바들 또는 이슈필터바에서 목록을 클릭했을때

2. Input Search 에서 값을 직접적으로 입력하고 엔터키를 눌럿을때 api가 요청된다고 생각하여 작업했습니다. (부정확한 key가 들어있을시에는 바로 리턴되도록 하였고 이후에 사용자에게 어떤식으로 보여줄지는 고민입니다.)

해당 api가 오기전까지 다음 작업은 이슈 메인페이지 체크박스쪽과 제가 작성한 코드들 리팩토링하면서 Jest를 좀 만져볼까 생각중이에요.