### PR TITLE
[FE] 운영 환경에서 불필요한 코드 삭제, lazy suspense 체험?

### DIFF
--- a/FE/.babelrc
+++ b/FE/.babelrc
@@ -1,3 +1,19 @@
 {
-    "presets": ["@babel/preset-react", "@babel/preset-env", "@babel/typescript"]
+    "presets": [[
+        "@babel/preset-env",
+        {
+          "targets": "> 1%, not dead",
+          "useBuiltIns": "usage",
+          "corejs": { "version": "3" }
+        }
+      ],
+      [
+        "@babel/preset-react",
+        {
+          "runtime": "automatic",
+          "importSource": "@emotion/react"
+        }
+      ],
+      "@babel/preset-typescript"
+    ]
 }

--- a/FE/config/webpack.common.js
+++ b/FE/config/webpack.common.js
@@ -32,24 +32,6 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: [
-              [
-                '@babel/preset-env',
-                {
-                  targets: '> 1%, not dead',
-                  useBuiltIns: 'usage',
-                  corejs: { version: '3' },
-                },
-              ],
-              [
-                '@babel/preset-react',
-                {
-                  runtime: 'automatic',
-                  importSource: '@emotion/react',
-                },
-              ],
-              '@babel/preset-typescript',
-            ],
             plugins: [
               [
                 '@emotion/babel-plugin',

--- a/FE/src/Router.tsx
+++ b/FE/src/Router.tsx
@@ -1,41 +1,54 @@
+import { css } from '@emotion/react';
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
-import Layout from '@components/Layout';
-import AccessDeniedPage from '@pages/AccessDeniedPage';
+import { Loader } from '@components/Indicator/Loader';
 import ButtonPage from '@pages/ButtonPage';
 import Callback from '@pages/Callback';
 import IconPage from '@pages/IconPage';
-import IssuePage from '@pages/IssuePage';
-import IssueDetailPage from '@pages/IssuePage/Detail';
-import LabelPage from '@pages/LabelPage';
-import Login from '@pages/Login';
-import Milestone from '@pages/MilestonePage';
 import NotFound from '@pages/NotFound';
 import Verification from '@pages/Verification';
+import { alignPosXY } from '@styles/mixin';
+
+const LoginPage = lazy(() => import('@pages/Login'));
+const Layout = lazy(() => import('@components/Layout'));
+const IssuePage = lazy(() => import('@pages/IssuePage'));
+const IssueDetailPage = lazy(() => import('@pages/IssuePage/Detail'));
+const LabelPage = lazy(() => import('@pages/LabelPage'));
+const MilestonePage = lazy(() => import('@pages/MilestonePage'));
+const AccessDeniedPage = lazy(() => import('@pages/AccessDeniedPage'));
 
 export default function Router() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Login />} />
+      <div
+        css={css`
+          ${alignPosXY('fixed')}
+        `}
+      >
+        <Suspense fallback={<Loader text="데이터 수신 중입니다." size={16} />}>
+          <Routes>
+            <Route path="/" element={<LoginPage />} />
 
-        <Route element={<Verification />}>
-          <Route path="/issue" element={<Layout />}>
-            <Route index element={<IssuePage />} />
-            <Route path="new" element={<IssueDetailPage />} />
-            <Route path=":id" element={<IssueDetailPage />} />
-            {/**/}
-            <Route path="label" element={<LabelPage />} />
-            <Route path="milestone" element={<Milestone />} />
-          </Route>
-        </Route>
+            <Route element={<Verification />}>
+              <Route path="/issue" element={<Layout />}>
+                <Route index element={<IssuePage />} />
+                <Route path="new" element={<IssueDetailPage />} />
+                <Route path=":id" element={<IssueDetailPage />} />
+                {/**/}
+                <Route path="label" element={<LabelPage />} />
+                <Route path="milestone" element={<MilestonePage />} />
+              </Route>
+            </Route>
 
-        <Route path="/icons" element={<IconPage />} />
-        <Route path="/buttons" element={<ButtonPage />} />
-        <Route path="/callback" element={<Callback />} />
-        <Route path="/error" element={<AccessDeniedPage />} />
-        <Route path="/*" element={<NotFound />} />
-      </Routes>
+            <Route path="/icons" element={<IconPage />} />
+            <Route path="/buttons" element={<ButtonPage />} />
+            <Route path="/callback" element={<Callback />} />
+            <Route path="/error" element={<AccessDeniedPage />} />
+            <Route path="/*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
+      </div>
     </BrowserRouter>
   );
 }

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -1,8 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
+// import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 
 import './index.css';
@@ -31,7 +30,6 @@ root.render(
       <RecoilRoot>
         <GlobalStyle />
         <App />
-        <ReactQueryDevtools initialIsOpen={false} />
       </RecoilRoot>
     </ThemeProvider>
   </QueryClientProvider>,

--- a/FE/src/pages/IssuePage/Detail/Main/index.tsx
+++ b/FE/src/pages/IssuePage/Detail/Main/index.tsx
@@ -39,7 +39,7 @@ export const NewMain = () => {
 
   const handleClickCancelButton = useCallback(
     () => navigate(issuePagePath),
-    [],
+    [navigate],
   );
   const handleClickSubmitButton = (e: React.FormEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/FE/src/pages/LabelPage/style.ts
+++ b/FE/src/pages/LabelPage/style.ts
@@ -65,7 +65,8 @@ export const Main = styled.div`
   border: 1px solid;
   border-color: ${({ theme }) => theme.color.line};
   border-radius: 1rem;
-  overflow: hidden;
+  overflow: scroll;
+  max-height: 34rem;
 `;
 
 export const LabelPageLayer = styled.div`


### PR DESCRIPTION
## 🤷‍♂️ Description

lazy, suspense를 라우터에 적용해봤는데 성능상 운영에서 좋아질지는 운영에서 다시 한 번 측정해봐야 알 것 같아요!

우선 lazy, suspense를 공부하면서 라우터쪽에 먼저 도입하는게 적합하다고 공식문서에 나와있었습니다.
적용 이유
1. 서버 측에서 렌더링하지 않는 경우 'React.lazy()'로 자바스크립트 번들을 분할하는 방법
2. 컴포넌트가 렌더링 될 때 파일이 import 되기 때문에
3. 해당 파일을 받아오기전에 Suspense 컴포넌트 안에 fallback 속성에 대체로 보여줄 화면을 출력할 수도 있음 => 이전에 만드신 로딩창 가져다가 보여주도록 했습니다.

Error Boundary도 적용해보면 좋을 것 같은데 이 부분은 좀 더 학습이 필요 할 것 같아요.

